### PR TITLE
Icon component - height width fix

### DIFF
--- a/packages/terra-consumer-icon/CHANGELOG.md
+++ b/packages/terra-consumer-icon/CHANGELOG.md
@@ -4,3 +4,7 @@ ChangeLog
 1.0.0 - (August 22, 2017)
 -----------------
 Initial stable release. Icons included with scripts to generate.
+
+1.1.0 - (August 25, 2017)
+-----------------
+Updated script to not consider height and width from original svg source. Updated existing icon also.

--- a/packages/terra-consumer-icon/scripts/src/generate-icon/Icon.js
+++ b/packages/terra-consumer-icon/scripts/src/generate-icon/Icon.js
@@ -11,6 +11,9 @@ class Icon {
     this.attributes = classNamesToAttributes(Array.prototype.slice.call(node.attributes)
       .map(x => ({ name: htmlToReactAttributes(x.name), value: x.value }))
       .reduce((attrs, x) => Object.assign({ [x.name]: x.value }, attrs), {}));
+    // deleting height and width attributes as we can set this at consumer level
+    delete this.attributes.height;
+    delete this.attributes.width;
   }
 }
 

--- a/packages/terra-consumer-icon/src/icon/IconChatBubble.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconChatBubble.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconChatBubble";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorAward49.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorAward49.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorAward49";
-SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
+SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorBloodGlucose.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorBloodGlucose.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorBloodGlucose";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorBloodPressure.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorBloodPressure.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorBloodPressure";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorFootsteps.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorFootsteps.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorFootsteps";
-SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
+SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorHeartRate.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorHeartRate.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorHeartRate";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorIncentives.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorIncentives.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorIncentives";
-SvgIcon.defaultProps = {"viewBox":"0 0 24 24","height":"24","width":"24","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 24 24","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorPeakFlow.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorPeakFlow.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorPeakFlow";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorPulseOximetry.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorPulseOximetry.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorPulseOximetry";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorRunning.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorRunning.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorRunning";
-SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
+SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconColorWeightScale.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconColorWeightScale.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconColorWeightScale";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconDataSync.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconDataSync.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconDataSync";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconErrorPage.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconErrorPage.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconErrorPage";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconNoData.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconNoData.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconNoData";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconNoMatchingResults.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconNoMatchingResults.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconNoMatchingResults";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconNotAuthorized.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconNotAuthorized.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconNotAuthorized";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineAdd.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineAdd.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineAdd";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineApple.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineApple.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineApple";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineAwardRibbon.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineAwardRibbon.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineAwardRibbon";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineCalendarDays.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineCalendarDays.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineCalendarDays";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineCalendarSimple.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineCalendarSimple.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineCalendarSimple";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineCertificate.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineCertificate.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineCertificate";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineCheck.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineCheck.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineCheck";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineChevronDown.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineChevronDown.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineChevronDown";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineChevronLeft.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineChevronLeft.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineChevronLeft";
-SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
+SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineChevronRight.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineChevronRight.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineChevronRight";
-SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
+SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineChevronUp.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineChevronUp.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineChevronUp";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineCigarette.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineCigarette.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineCigarette";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineCog.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineCog.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineCog";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineDonutChart.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineDonutChart.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineDonutChart";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineError.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineError.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineError";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineEyeglasses.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineEyeglasses.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineEyeglasses";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineFilter.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineFilter.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineFilter";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineFingerprint.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineFingerprint.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineFingerprint";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineFootsteps.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineFootsteps.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineFootsteps";
-SvgIcon.defaultProps = {"viewBox":"0 0 24 24","height":"24","width":"24","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 24 24","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineGrowth.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineGrowth.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineGrowth";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineHeartBeat.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineHeartBeat.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineHeartBeat";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineIncentives.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineIncentives.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineIncentives";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineInformation.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineInformation.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineInformation";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineLifesaver.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineLifesaver.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineLifesaver";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineLink.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineLink.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineLink";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineLocationPin.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineLocationPin.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineLocationPin";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineMartini.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineMartini.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineMartini";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineMeditation.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineMeditation.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineMeditation";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineNav.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineNav.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineNav";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineNeedle.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineNeedle.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineNeedle";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineProductivity.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineProductivity.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineProductivity";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineQuestionMark.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineQuestionMark.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineQuestionMark";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineRunning.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineRunning.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineRunning";
-SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
+SvgIcon.defaultProps = {"className":"","viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg","isBidi":true};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineRunningShoe.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineRunningShoe.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineRunningShoe";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineSquareHeartRate.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineSquareHeartRate.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineSquareHeartRate";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineSuccess.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineSuccess.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineSuccess";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineUserEdit.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineUserEdit.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineUserEdit";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineUserLock.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineUserLock.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineUserLock";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineUsersHouse.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineUsersHouse.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineUsersHouse";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineVitalsCircle.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineVitalsCircle.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineVitalsCircle";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineWarning.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineWarning.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineWarning";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconOutlineWeightScale.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconOutlineWeightScale.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconOutlineWeightScale";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconSensitiveData.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconSensitiveData.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconSensitiveData";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/src/icon/IconUiColor1CalendarGrid61.jsx
+++ b/packages/terra-consumer-icon/src/icon/IconUiColor1CalendarGrid61.jsx
@@ -13,7 +13,7 @@ const SvgIcon = (customProps) => {
 };
 
 SvgIcon.displayName = "IconUiColor1CalendarGrid61";
-SvgIcon.defaultProps = {"viewBox":"0 0 48 48","height":"48","width":"48","xmlns":"http://www.w3.org/2000/svg"};
+SvgIcon.defaultProps = {"viewBox":"0 0 48 48","xmlns":"http://www.w3.org/2000/svg"};
 
 export default SvgIcon;
 /* eslint-enable */

--- a/packages/terra-consumer-icon/tests/jest/Icon.test.jsx
+++ b/packages/terra-consumer-icon/tests/jest/Icon.test.jsx
@@ -17,7 +17,7 @@ describe('Icon', () => {
     describe('height prop', () => {
       it('should have default height="1em"', () => {
         const wrapper = shallow(<IconChatBubble />);
-        expect(wrapper.prop('height')).toEqual('48');
+        expect(wrapper.prop('height')).toEqual('1em');
       });
       it('should have height=50', () => {
         const wrapper = shallow(<IconChatBubble height="50" />);
@@ -32,7 +32,7 @@ describe('Icon', () => {
     describe('width prop', () => {
       it('should have default width="1em"', () => {
         const wrapper = shallow(<IconChatBubble />);
-        expect(wrapper.prop('width')).toEqual('48');
+        expect(wrapper.prop('width')).toEqual('1em');
       });
       it('should have width=50', () => {
         const wrapper = shallow(<IconChatBubble width="50" />);
@@ -98,7 +98,7 @@ describe('Icon', () => {
     describe('height prop', () => {
       it('should have default height="1em"', () => {
         const wrapper = shallow(<IconColorIncentives />);
-        expect(wrapper.prop('height')).toEqual('24');
+        expect(wrapper.prop('height')).toEqual('1em');
       });
       it('should have height=50', () => {
         const wrapper = shallow(<IconColorIncentives height="50" />);
@@ -113,7 +113,7 @@ describe('Icon', () => {
     describe('width prop', () => {
       it('should have default width="1em"', () => {
         const wrapper = shallow(<IconColorIncentives />);
-        expect(wrapper.prop('width')).toEqual('24');
+        expect(wrapper.prop('width')).toEqual('1em');
       });
       it('should have width=50', () => {
         const wrapper = shallow(<IconColorIncentives width="50" />);
@@ -184,7 +184,7 @@ describe('Icon', () => {
     describe('height prop', () => {
       it('should have default height="1em"', () => {
         const wrapper = shallow(<IconOutlineChevronRight />);
-        expect(wrapper.prop('height')).toEqual('48');
+        expect(wrapper.prop('height')).toEqual('1em');
       });
       it('should have height=50', () => {
         const wrapper = shallow(<IconOutlineChevronRight height="50" />);
@@ -199,7 +199,7 @@ describe('Icon', () => {
     describe('width prop', () => {
       it('should have default width="1em"', () => {
         const wrapper = shallow(<IconOutlineChevronRight />);
-        expect(wrapper.prop('width')).toEqual('48');
+        expect(wrapper.prop('width')).toEqual('1em');
       });
       it('should have width=50', () => {
         const wrapper = shallow(<IconOutlineChevronRight width="50" />);

--- a/packages/terra-consumer-icon/tests/jest/__snapshots__/Icon.test.jsx.snap
+++ b/packages/terra-consumer-icon/tests/jest/__snapshots__/Icon.test.jsx.snap
@@ -4,11 +4,11 @@ exports[`Icon IconChatBubble should shallow IconBase 1`] = `
 <IconBase
   ariaLabel={null}
   focusable={false}
-  height="48"
+  height="1em"
   isBidi={false}
   isSpin={false}
   viewBox="0 0 48 48"
-  width="48"
+  width="1em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -44,11 +44,11 @@ exports[`Icon IconColorIncentives should shallow IconBase 1`] = `
 <IconBase
   ariaLabel={null}
   focusable={false}
-  height="24"
+  height="1em"
   isBidi={false}
   isSpin={false}
   viewBox="0 0 24 24"
-  width="24"
+  width="1em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -102,9 +102,9 @@ exports[`Icon IconOutlineChevronRight should render IconBase with custom-class 1
   aria-hidden="true"
   class="icon is-bidi custom-class"
   focusable="false"
-  height="48"
+  height="1em"
   viewbox="0 0 48 48"
-  width="48"
+  width="1em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path
@@ -123,11 +123,11 @@ exports[`Icon IconOutlineChevronRight should shallow IconBase 1`] = `
   ariaLabel={null}
   className=""
   focusable={false}
-  height="48"
+  height="1em"
   isBidi={true}
   isSpin={false}
   viewBox="0 0 48 48"
-  width="48"
+  width="1em"
   xmlns="http://www.w3.org/2000/svg"
 >
   <path

--- a/packages/terra-consumer-icon/tests/nightwatch/icon-spec.js
+++ b/packages/terra-consumer-icon/tests/nightwatch/icon-spec.js
@@ -19,18 +19,18 @@ module.exports = {
       .expect.element('#icon-default').to.have.attribute('aria-hidden').which.contains('true');
   },
 
-  'Displays a default icon with height equal to 48': (browser) => {
+  'Displays a default icon with height equal to 1em': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/icon-tests/default`)
       .waitForElementPresent('#icon-default', 1000)
-      .expect.element('#icon-default').to.have.attribute('height').which.contains('48');
+      .expect.element('#icon-default').to.have.attribute('height').which.contains('1em');
   },
 
-  'Displays a default icon with width equal to 48': (browser) => {
+  'Displays a default icon with width equal to 1em': (browser) => {
     browser
       .url(`${browser.launchUrl}/#/tests/icon-tests/default`)
       .waitForElementPresent('#icon-default', 1000)
-      .expect.element('#icon-default').to.have.attribute('width').which.contains('48');
+      .expect.element('#icon-default').to.have.attribute('width').which.contains('1em');
   },
 
   'Displays a default icon with focusable equal to false': (browser) => {


### PR DESCRIPTION
### Summary
The original SVG is having width and height attributes set which is forcing consumer to overwrite them as per their use case.

Solution:
Updated script to not consider width and height attributes from svg.
Generated all icon again with update script.
Updated test.

cc: @Mahmud-Khan 
