### PR TITLE
Nav ui uplift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ target
 lib
 props-table
 package-lock.json
+*.tgz

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -9,6 +9,7 @@ ChangeLog
 
 ### Changed
 - Minor UI fixes.
+- Font antialiased fixes for chrome/firefox.
 - Hover effects for nav-items (mobile/desktop)
 - Scrolling content on help popup no longer scrolls title.
 - Removed id as prop requirement for help/profile.

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,6 +1,21 @@
 ChangeLog
 =========
 
+# 0.1.0-BETA.4 - (August 29, 2017)
+
+### Added
+- Profile now has option to display sign-in link.
+- Profile now overlays items on long navigation lists.
+
+### Changed
+- Minor UI fixes.
+- Hover effects for nav-items (mobile/desktop)
+- Scrolling content on help popup no longer scrolls title.
+- Removed id as prop requirement for help/profile.
+- Multiple help togglers do not open simultaneously, although there can be more than one open at a time.
+
+-----------------
+
 # 0.1.0-BETA.3 - (August 25, 2017)
 
 ### Added

--- a/packages/terra-consumer-nav/src/Nav.jsx
+++ b/packages/terra-consumer-nav/src/Nav.jsx
@@ -19,9 +19,11 @@ const propTypes = {
   /**
    * An array of objects to be displayed as quick link options.
    */
-  quickLinks: PropTypes.arrayOf(PropTypes.shape({
-    text: PropTypes.string.isRequired,
-  })),
+  quickLinks: PropTypes.arrayOf(
+    PropTypes.shape({
+      text: PropTypes.string.isRequired,
+    }),
+  ),
   /**
    * An array of objects to be displayed as nav link options.
    */

--- a/packages/terra-consumer-nav/src/Nav.jsx
+++ b/packages/terra-consumer-nav/src/Nav.jsx
@@ -28,22 +28,11 @@ const propTypes = {
    * An array of objects to be displayed as nav link options.
    */
   navItems: PropTypes.array.isRequired,
-  /**
-   * An array of nav items to be displayed on the user profile/ settings menu/popup.
-   */
-  profileLinks: PropTypes.array.isRequired,
-  /**
-   * User name to be displayed in the profile in navigation.
-   */
-  userName: PropTypes.string.isRequired,
-  /**
-   * Avatar to be displayed in user profile in navigation.
-   */
-  avatar: PropTypes.PropTypes.element,
-  /**
-   * The path signout button would redirect to.
-   */
-  signoutUrl: PropTypes.string.isRequired,
+
+  profile: PropTypes.shape({
+    signinUrl: PropTypes.string,
+    avatar: PropTypes.element,
+  }),
   /**
    * An object defining the logo to be displayed
    */
@@ -74,8 +63,7 @@ const propTypes = {
 const defaultProps = {
   quickLinks: [],
   navItems: [],
-  profileLinks: [],
-  avatar: null,
+  profile: {},
   logo: {},
 };
 
@@ -110,8 +98,10 @@ class Nav extends React.Component {
   }
 
   render() {
-    const { quickLinks, navItems, profileLinks, userName, avatar, signoutUrl, logo, isMobileNavOpen, onRequestClose, ...customProps } = this.props;
+    const { quickLinks, navItems, profile, logo, isMobileNavOpen, onRequestClose, ...customProps } = this.props;
     const profileId = 'profile-popup-button';
+
+    const willRenderProfile = profile.userName || profile.avatar || profile.signinUrl;
 
     const defaultElement = (
       <Modal
@@ -138,7 +128,7 @@ class Nav extends React.Component {
     );
 
     return (
-      <div className={cx('nav')}>
+      <div id="terra-consumer-nav">
         <div {...customProps} className={cx('nav', customProps.className)} aria-hidden={!isMobileNavOpen}>
           <Button icon={<IconClose />} className={cx('close-button')} onClick={() => { onRequestClose(); }} />
           <NavLogo {...logo} />
@@ -146,14 +136,14 @@ class Nav extends React.Component {
             {quickLinks.map(element => <QuickLink {...element} key={element.text} />)}
           </QuickLinks>
           <NavItems navItems={navItems} />
-          <UserProfile
-            profileLinks={profileLinks}
-            name={userName}
-            avatar={avatar}
-            id={profileId}
-            signoutUrl={signoutUrl}
-            handleClick={(modalContent) => { this.toggleModal(modalContent); }}
-          />
+          { willRenderProfile &&
+            <UserProfile
+              {...profile}
+              id={profileId}
+              handleClick={(modalContent) => { this.toggleModal(modalContent); }}
+              isSignIn={profile.signinUrl && !(profile.avatar || profile.userName)}
+            />
+          }
         </div>
         <ResponsiveElement responsiveTo="window" defaultElement={defaultElement} medium={popup} />
       </div>

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -4,15 +4,21 @@
 :local {
   .nav {
     background: inherit;
-    left: 0;
-    max-height: 100vh;
-    min-height: 100vh;
+    height: 100%;
     overflow-y: auto;
+    padding-bottom: 60px;
+    padding-top: var(--terra-consumer--nav-padding-top, 25px);
     position: relative;
+    top: 0;
     width: inherit;
 
     @media screen and (max-width: $terra-tiny-breakpoint) {
       width: 100vw;
+    }
+
+    @media screen and (max-width: $terra-medium-breakpoint) {
+      height: 100vh;
+      padding-top: var(--terra-consumer--mobile-nav-padding-top, 0);
     }
   }
 
@@ -47,8 +53,10 @@
       top: 0;
     }
 
-    &:hover {
+    &:hover,
+    &:focus {
       background: var(--terra-consumer--mobile-close-button-hover-background, none);
+      border-radius: 3px;
       color: var(--terra-consumer--mobile-close-button-hover-color, #ccc);
     }
   }

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -49,7 +49,7 @@
 
     &:hover {
       background: var(--terra-consumer--mobile-close-button-hover-background, none);
-      color: var(--terra-consumer--mobile-close-button-hover-color, #777);
+      color: var(--terra-consumer--mobile-close-button-hover-color, #ccc);
     }
   }
 }

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -4,9 +4,8 @@
 :local {
   .nav {
     background: inherit;
-    height: 100%;
+    max-height: calc(100vh - 60px);
     overflow-y: auto;
-    padding-bottom: 60px;
     padding-top: var(--terra-consumer--nav-padding-top, 25px);
     position: relative;
     top: 0;

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700');
+@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700,900');
 @import './variables';
 
 :local {

--- a/packages/terra-consumer-nav/src/NavPropShapes.js
+++ b/packages/terra-consumer-nav/src/NavPropShapes.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-const navItemShape = {
+export const navItemShape = {
   /**
    * Text to be displayed in profile link.
    */
@@ -27,4 +27,10 @@ const navItemShape = {
   badgeValue: PropTypes.number,
 };
 
-export default navItemShape;
+export const navItemShapeDefaults = {
+  url: '',
+  icon: null,
+  target: '_self',
+  isActive: false,
+  badgeValue: 0,
+};

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.jsx
@@ -69,7 +69,7 @@ class NavHelp extends React.Component {
         className={cx('nav-help')}
       >
         <Arrange
-          fill={<div className={cx('icon')} ><IconOutlineQuestionMark /></div>}
+          fill={<IconOutlineQuestionMark />}
           fitEnd={<div className={cx('button-text-padding')}><FormattedMessage id="nav_help" /></div>}
           align="stretch"
         />
@@ -106,7 +106,7 @@ class NavHelp extends React.Component {
     return (
       <div {...customProps}>
         <ResponsiveElement responsiveTo="window" defaultElement={defaultElement} medium={popup} />
-        {!this.state.isOpen && helpButton}
+        {helpButton}
       </div>
     );
   }

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.jsx
@@ -32,7 +32,7 @@ const propTypes = {
   /**
    * A unique id set to the help button that will be referred in help menu/popup .
    */
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
   /**
    * Injected react-intl formatting api
    */
@@ -40,6 +40,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  id: '--terra-consumer--nav-help-button',
   helpNavs: [],
 };
 

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.jsx
@@ -40,7 +40,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  id: '--terra-consumer--nav-help-button',
+  id: 'terra-consumer-nav-help-button',
   helpNavs: [],
 };
 

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
@@ -26,11 +26,6 @@
       color: inherit;
     }
   }
-    
-  .icon svg {
-    height: 16px;
-    width: 16px;
-  }
 
   .help-item {
     background: var(--terra-consumer--nav-help-item-background, #fff);
@@ -45,7 +40,7 @@
       background: var(--terra-consumer--nav-help-item-background, #eee);
       cursor: pointer;
     }
-    
+
     &:focus {
       background: var(--terra-consumer--nav-help-item-background, #eee);
     }
@@ -62,7 +57,7 @@
   .help-item-border {
     border-top: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
   }
-  
+
   .help-subitem {
     color: var(--terra-consumer--nav-help-subitem-text-color, #64696c);
     font-size: 14px;
@@ -97,9 +92,7 @@
     bottom: 0;
     box-shadow: 0 1px 1px #666;
     margin-bottom: 15px;
-    margin-left: 0;
     margin-right: 15px;
-    margin-top: 0;
     position: relative;
     right: 0;
   }

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
@@ -19,7 +19,7 @@
     }
 
     &:focus {
-      background: var(--terra-consumer--nav-help-button-background, #eee);
+      background: var(--terra-consumer--nav-help-button-focus-background, #eee);
     }
 
     &:active {
@@ -37,14 +37,13 @@
     width: 100%;
 
     &:hover {
-      background: var(--terra-consumer--nav-help-item-background, #eee);
+      background: var(--terra-consumer--nav-help-item-hover-background, #eee);
       cursor: pointer;
     }
 
     &:focus {
-      background: var(--terra-consumer--nav-help-item-background, #eee);
+      background: var(--terra-consumer--nav-help-item-focus-background, #eee);
     }
-
   }
 
   .help-item-text {
@@ -89,11 +88,8 @@
 
   .popup-content {
     border-radius: 5px;
-    bottom: 0;
-    box-shadow: 0 1px 1px #666;
     margin-bottom: 15px;
     margin-right: 15px;
-    position: relative;
-    right: 0;
+    position: var(--terra-consumer--popup-content-position, relative);
   }
 }

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
@@ -30,6 +30,7 @@
   .help-item {
     background: var(--terra-consumer--nav-help-item-background, #fff);
     border: 0;
+    border-bottom: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
     border-radius: 0;
     font-family: inherit;
     padding: 20px;
@@ -51,10 +52,6 @@
     font-size: 14px;
     line-height: 18px;
     text-align: left;
-  }
-
-  .help-item-border {
-    border-top: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
   }
 
   .help-subitem {
@@ -88,8 +85,9 @@
 
   .popup-content {
     border-radius: 5px;
-    margin-bottom: 15px;
-    margin-right: 15px;
-    position: var(--terra-consumer--popup-content-position, relative);
+    box-shadow: 0 1px 1px #666;
+    margin: 0 15px 15px 0;
+    overflow: hidden !important;
+    position: relative;
   }
 }

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -12,35 +12,46 @@ const cx = classNames.bind(styles);
 class NavHelpContent extends React.Component {
   constructor() {
     super();
-    this.state = ({ isOpen: false });
+    this.state = ({ openTogglers: [] });
 
     this.handleToggle = this.handleToggle.bind(this);
   }
 
-  handleToggle() {
-    this.setState({ isOpen: !this.state.isOpen });
+  handleToggle(toggleIndex) {
+    const newState = Object.assign([], this.state.openTogglers);
+    const index = newState.findIndex(elem => elem === toggleIndex);
+    if (index !== -1) {
+      newState.splice(index, 1);
+    } else {
+      newState.push(toggleIndex);
+    }
+    this.setState({
+      openTogglers: newState,
+    });
   }
 
   render() {
     const { ...customProps } = this.props;
-    const toggleIcon = this.state.isOpen ? <IconChevronUp className={cx('icon')} /> : <IconChevronDown className={cx('icon')} />;
 
-    const contentList = customProps.helpContent.map((content, i) => {
+    const contentList = customProps.helpContent.map((content, index) => {
       let contentElement;
+      const isOpen = this.state.openTogglers.some(elem => elem === index);
+      const toggleIcon = isOpen ? <IconChevronUp className={cx('icon')} /> : <IconChevronDown className={cx('icon')} />;
+
       if (content.children.length > 0) {
         contentElement = (<Button
           key={`${content.text}`}
-          onClick={this.handleToggle}
-          className={i > 0 ? cx('help-item', 'help-item-border') : cx('help-item')}
+          onClick={() => this.handleToggle(index)}
+          className={cx('help-item')}
         >
           <Arrange
             className={cx('help-item-text')}
             align="stretch"
-            fitStart={<div className={cx('icon')}>{content.icon}</div>}
+            fitStart={<div>{content.icon}</div>}
             fill={<div className={cx('item-text-padding')}>{content.text}</div>}
-            fitEnd={<div className={cx('icon')}>{toggleIcon}</div>}
+            fitEnd={<div>{toggleIcon}</div>}
           />
-          <Toggler isOpen={this.state.isOpen} isAnimated className={cx('toggler-padding')}>
+          <Toggler isOpen={isOpen} isAnimated className={cx('toggler-padding')}>
             { content.children.map(element => (
               <p key={`${element.text}`} className={cx('toggler-content-alignment')}>
                 <span className={cx('help-subitem')}>
@@ -51,7 +62,7 @@ class NavHelpContent extends React.Component {
           </Toggler>
         </Button>);
       } else {
-        contentElement = (<Button key={`${content.text}`} href={content.url} className={i > 0 ? cx('help-item', 'help-item-border') : cx('help-item')} >
+        contentElement = (<Button key={`${content.text}`} href={content.url} className={cx('help-item')} >
           <Arrange
             className={cx('help-item-text')}
             align="center"

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -12,21 +12,14 @@ const cx = classNames.bind(styles);
 class NavHelpContent extends React.Component {
   constructor() {
     super();
-    this.state = ({ openTogglers: [] });
+    this.state = ({ togglers: {} });
 
     this.handleToggle = this.handleToggle.bind(this);
   }
 
   handleToggle(toggleIndex) {
-    const newState = Object.assign([], this.state.openTogglers);
-    const index = newState.findIndex(elem => elem === toggleIndex);
-    if (index !== -1) {
-      newState.splice(index, 1);
-    } else {
-      newState.push(toggleIndex);
-    }
     this.setState({
-      openTogglers: newState,
+      togglers: { ...this.state.togglers, [toggleIndex]: !this.state.togglers[toggleIndex] },
     });
   }
 
@@ -35,7 +28,7 @@ class NavHelpContent extends React.Component {
 
     const contentList = customProps.helpContent.map((content, index) => {
       let contentElement;
-      const isOpen = this.state.openTogglers.some(elem => elem === index);
+      const isOpen = this.state.togglers[index];
       const toggleIcon = isOpen ? <IconChevronUp className={cx('icon')} /> : <IconChevronDown className={cx('icon')} />;
 
       if (content.children.length > 0) {

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpPopup.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpPopup.jsx
@@ -65,7 +65,9 @@ const NavHelpPopup = ({
     >
       <div>
         {popupHeader}
-        {popupContent}
+        <div className={cx('popup-body')}>
+          {popupContent}
+        </div>
       </div>
     </TerraPopup>
   );

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpPopup.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpPopup.scss
@@ -20,7 +20,7 @@
 
     &:hover {
       background: none;
-      color: var(--terra-consumer--popup-close-button-hover-color, #777);
+      color: var(--terra-consumer--popup-close-button-hover-color, #ccc);
       cursor: pointer;
     }
 
@@ -28,5 +28,10 @@
       background: none;
       color: var(--terra-consumer--popup-close-button-hover-color, #777);
     }
+  }
+
+  .popup-body {
+    height: 200px;
+    overflow: scroll;
   }
 }

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
@@ -54,13 +54,14 @@ const NavItem = ({
     <Arrange
       fitStart={icon ? <span className={cx('nav-item-icon')}>{icon}</span> : null}
       fill={
-        <div className={cx(icon && 'nav-item-text')}>
+        <div className={cx(icon ? 'nav-item-text' : 'nav-item-no-icon')}>
           {text}
           { badgeValue > 0 &&
             <div className={cx('badge')}>{badgeValue}</div>
           }
         </div>
       }
+      align="center"
     />
   );
 

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
@@ -75,7 +75,7 @@ const NavItem = ({
     </NavToggler>)
   :
   (<div className={activeClass}>
-    <a href={url} target={target} className={cx('nav-item')}>
+    <a href={url} target={target} className={cx('nav-item', 'nav-item-link')}>
       {itemText}
     </a>
   </div>);

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
@@ -16,37 +16,54 @@
     }
   }
 
-  .nav-item-text {
-    padding-left: 20px;
-  }
-
-  .nav-item-link {
-    &:hover {
-      color: #000;
-      text-decoration: underline;
-      @media screen and (max-width: $terra-medium-breakpoint) {
-        color: #fff;
-      }
+  .nav-item-wrapper.nav-item-icon {
+    .nav-item-no-icon {
+      padding-left: 15px;
     }
   }
 
+  .nav-item-text,
+  .nav-item-no-icon {
+    display: flex;
+  }
+
+  /* stylelint-disable selector-max-compound-selectors, max-nesting-depth */
   .nav-item-wrapper {
     padding-bottom: 20px;
+
+    .nav-item-text {
+      padding-left: 20px;
+    }
+
+    .nav-item-link {
+      &:hover,
+      &:focus {
+        color: #000;
+        text-decoration: underline;
+        @media screen and (max-width: $terra-medium-breakpoint) {
+          color: #fff;
+        }
+      }
+    }
 
     .nav-item-wrapper {
       margin-top: 15px;
       padding-bottom: 0;
-      padding-left: 20px;
+      padding-left: 35px;
+
+      .nav-item-text {
+        padding-left: 10px;
+      }
     }
   }
 
   // colors here need callouts, on the way. using estimated from mockups
   .badge {
+    align-self: center;
     background: var(--terra-consumer--badge-background, #fff);
     border-radius: 10px;
     color: var(--terra-consumer--badge-text-color, inherit);
-    display: inline-block;
-    margin-left: 10px;
+    margin: 0 10px;
     padding: 0 7px;
     @media screen and (max-width: $terra-medium-breakpoint) {
       background: var(--terra-consumer--mobile-badge-background, #aaa);

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
@@ -20,6 +20,16 @@
     padding-left: 20px;
   }
 
+  .nav-item-link {
+    &:hover {
+      color: #000;
+      text-decoration: underline;
+      @media screen and (max-width: $terra-medium-breakpoint) {
+        color: #fff;
+      }
+    }
+  }
+
   .nav-item-wrapper {
     padding-bottom: 20px;
 

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
@@ -17,7 +17,7 @@
   }
 
   .nav-item-text {
-    padding-left: 5px;
+    padding-left: 20px;
   }
 
   .nav-item-wrapper {

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItems.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItems.jsx
@@ -67,6 +67,7 @@ class NavItems extends Component {
           icon={element.icon}
           isActive={element.isActive}
           badgeValue={element.badgeValue}
+          className={element.icon && 'nav-item-icon'}
           {...toggleProps}
         >
           {subNavs}

--- a/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.jsx
@@ -33,7 +33,7 @@ const NavLogo = ({
   ...customProps
 }) => {
   const image = <img className={cx('img')} src={url} alt={altText} />;
-  const domNode = (isCard && url) ? Card : 'div';
+  const domNode = (isCard && !!url) ? Card : 'div';
   const logoClassNames = cx(
     'logo-container',
     customProps.className,

--- a/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.jsx
@@ -8,7 +8,7 @@ const propTypes = {
   /**
    *  The url of the logo to be shown.
    */
-  url: PropTypes.string.isRequired,
+  url: PropTypes.string,
   /**
    *  The alternate text that is read by screen readers or displayed if the image fails to load.
    */
@@ -33,7 +33,7 @@ const NavLogo = ({
   ...customProps
 }) => {
   const image = <img className={cx('img')} src={url} alt={altText} />;
-  const domNode = isCard ? Card : 'div';
+  const domNode = (isCard && url) ? Card : 'div';
   const logoClassNames = cx(
     'logo-container',
     customProps.className,

--- a/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.scss
+++ b/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.scss
@@ -12,6 +12,7 @@
   }
 
   .img {
+    color: #3d3d3d;
     display: block;
     margin: auto;
   }

--- a/packages/terra-consumer-nav/src/components/nav-toggler/NavToggler.scss
+++ b/packages/terra-consumer-nav/src/components/nav-toggler/NavToggler.scss
@@ -14,7 +14,8 @@
     text-decoration: none;
     width: 100%;
 
-    &:hover {
+    &:hover,
+    &:focus {
       color: #000;
       text-decoration: underline;
       @media screen and (max-width: $terra-medium-breakpoint) {

--- a/packages/terra-consumer-nav/src/components/nav-toggler/NavToggler.scss
+++ b/packages/terra-consumer-nav/src/components/nav-toggler/NavToggler.scss
@@ -13,6 +13,14 @@
     text-align: left;
     text-decoration: none;
     width: 100%;
+
+    &:hover {
+      color: #000;
+      text-decoration: underline;
+      @media screen and (max-width: $terra-medium-breakpoint) {
+        color: #fff;
+      }
+    }
   }
 
   .toggler {

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -7,7 +7,6 @@ import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import IconEllipses from 'terra-icon/lib/icon/IconEllipses';
 import IconPerson from 'terra-icon/lib/icon/IconPerson';
 import ProfileLinks from './ProfileLinks';
-import navElementShape from '../../NavPropShapes';
 import styles from './UserProfile.scss';
 
 const cx = classNames.bind(styles);
@@ -40,11 +39,7 @@ const propTypes = {
   /**
    * The content of the each profile items.
    */
-  profileLinks: PropTypes.arrayOf(
-    PropTypes.shape(
-      navElementShape,
-    ),
-  ),
+  profileLinks: PropTypes.array,
   /**
    * A function used as a callback to render modal and popup content.
    */
@@ -65,9 +60,9 @@ const defaultProps = {
 const UserProfile = ({
   userName, avatar, id, signoutUrl, signinUrl, isSignIn, profileLinks, handleClick, intl, ...customProps
 }) => {
-  let ret;
+  let profileContent;
   if (isSignIn) {
-    ret = (
+    profileContent = (
       <Button className={cx('popup-button')} href={signinUrl}>
         <Arrange
           fitStart={<div className={cx('avatar')}>{avatar}</div>}
@@ -77,7 +72,7 @@ const UserProfile = ({
       </Button>
     );
   } else {
-    const content = (
+    const popupContent = (
       <div>
         <ProfileLinks linkItems={profileLinks} />
         <Button className={cx('link', 'signout-border')} href={signoutUrl}>
@@ -88,8 +83,8 @@ const UserProfile = ({
 
     const title = intl.formatMessage({ id: 'nav_profile_title' });
 
-    ret = (
-      <Button className={cx('popup-button')} onClick={() => handleClick({ title, content })}>
+    profileContent = (
+      <Button className={cx('popup-button')} onClick={() => handleClick({ title, popupContent })}>
         <Arrange
           fitStart={<div className={cx('avatar')}>{avatar}</div>}
           fill={<span>{userName}</span>}
@@ -102,7 +97,7 @@ const UserProfile = ({
 
   return (
     <div {...customProps} className={cx('profile')}>
-      {ret}
+      {profileContent}
     </div>
   );
 };

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -14,31 +14,40 @@ const cx = classNames.bind(styles);
 
 const propTypes = {
   /**
-   * User name to be displayed in profile.
+   * User name to be displayed in profile if user is signed in.
    */
-  name: PropTypes.string.isRequired,
+  userName: PropTypes.string,
   /**
    * Avatar to be displayed in profile.
    */
-  avatar: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.element,
-  ]),
+  avatar: PropTypes.element,
   /**
    * A unique id set to the profile popup button that will be referred in profile popup.
    */
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
   /**
    * The path signout button would redirect to.
    */
   signoutUrl: PropTypes.string.isRequired,
   /**
+   * The path to the login page.
+   */
+  signinUrl: PropTypes.string,
+  /**
+   * Determiniate of whether profile should render as signin link or profile button.
+   */
+  isSignIn: PropTypes.bool,
+  /**
    * The content of the each profile items.
    */
-  profileLinks: PropTypes.arrayOf(PropTypes.shape(
-    navElementShape)),
-    /**
-    */
+  profileLinks: PropTypes.arrayOf(
+    PropTypes.shape(
+      navElementShape,
+    ),
+  ),
+  /**
+   * A function used as a callback to render modal and popup content.
+   */
   handleClick: PropTypes.func.isRequired,
   /**
    * Injected react-intl formatting api
@@ -47,37 +56,53 @@ const propTypes = {
 };
 
 const defaultProps = {
-  profile: {
-    avatar: null,
-    profileLinks: [],
-  },
+  avatar: <IconPerson />,
+  profileLinks: [],
+  isSignIn: false,
+  id: '--terra-conumser--nav-profile-button',
 };
 
-
 const UserProfile = ({
-  name, avatar, id, signoutUrl, profileLinks, handleClick, intl, ...customProps
+  userName, avatar, id, signoutUrl, signinUrl, isSignIn, profileLinks, handleClick, intl, ...customProps
 }) => {
-  const content = (
-    <div>
-      <ProfileLinks linkItems={profileLinks} />
-      <Button className={cx('link', 'signout-border')} href={signoutUrl}>
-        <FormattedMessage id="nav_signout" />
+  let ret;
+  if (isSignIn) {
+    ret = (
+      <Button className={cx('popup-button')} href={signinUrl}>
+        <Arrange
+          fitStart={<div className={cx('avatar')}>{avatar}</div>}
+          fill={<FormattedMessage id="nav_signin" />}
+          align="center"
+        />
       </Button>
-    </div>
-  );
+    );
+  } else {
+    const content = (
+      <div>
+        <ProfileLinks linkItems={profileLinks} />
+        <Button className={cx('link', 'signout-border')} href={signoutUrl}>
+          <FormattedMessage id="nav_signout" />
+        </Button>
+      </div>
+    );
 
-  const title = intl.formatMessage({ id: 'nav_profile_title' });
+    const title = intl.formatMessage({ id: 'nav_profile_title' });
 
-  return (
-    <div {...customProps} className={cx('profile')}>
+    ret = (
       <Button className={cx('popup-button')} onClick={() => handleClick({ title, content })}>
         <Arrange
-          fitStart={<div className={cx('avatar')}>{avatar || <IconPerson />}</div>}
-          fill={<span>{name}</span>}
+          fitStart={<div className={cx('avatar')}>{avatar}</div>}
+          fill={<span>{userName}</span>}
           fitEnd={<IconEllipses className={cx('icon')} id={id} />}
           align="center"
         />
       </Button>
+    );
+  }
+
+  return (
+    <div {...customProps} className={cx('profile')}>
+      {ret}
     </div>
   );
 };

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -54,7 +54,7 @@ const defaultProps = {
   avatar: <IconPerson />,
   profileLinks: [],
   isSignIn: false,
-  id: '--terra-conumser--nav-profile-button',
+  id: 'terra-conumser-nav-profile-button',
 };
 
 const UserProfile = ({

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -72,7 +72,7 @@ const UserProfile = ({
       </Button>
     );
   } else {
-    const popupContent = (
+    const content = (
       <div>
         <ProfileLinks linkItems={profileLinks} />
         <Button className={cx('link', 'signout-border')} href={signoutUrl}>
@@ -84,7 +84,7 @@ const UserProfile = ({
     const title = intl.formatMessage({ id: 'nav_profile_title' });
 
     profileContent = (
-      <Button className={cx('popup-button')} onClick={() => handleClick({ title, popupContent })}>
+      <Button className={cx('popup-button')} onClick={() => handleClick({ title, content })}>
         <Arrange
           fitStart={<div className={cx('avatar')}>{avatar}</div>}
           fill={<span>{userName}</span>}

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -5,6 +5,7 @@ import Button from 'terra-button';
 import classNames from 'classnames/bind';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import IconEllipses from 'terra-icon/lib/icon/IconEllipses';
+import IconPerson from 'terra-icon/lib/icon/IconPerson';
 import ProfileLinks from './ProfileLinks';
 import navElementShape from '../../NavPropShapes';
 import styles from './UserProfile.scss';
@@ -71,8 +72,8 @@ const UserProfile = ({
     <div {...customProps} className={cx('profile')}>
       <Button className={cx('popup-button')} onClick={() => handleClick({ title, content })}>
         <Arrange
-          fitStart={<svg className={cx('icon')}>{avatar}</svg>}
-          fill={<div className={cx('profile-text-padding')}>{name}</div>}
+          fitStart={<div className={cx('avatar')}>{avatar || <IconPerson />}</div>}
+          fill={<span>{name}</span>}
           fitEnd={<IconEllipses className={cx('icon')} id={id} />}
           align="center"
         />

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
@@ -14,11 +14,6 @@
     }
   }
 
-  .icon {
-    height: 16px;
-    width: 16px;
-  }
-
   .link {
     background: var(--terra-consumer--nav-profile-item-background, #fff);
     border: 0;
@@ -69,7 +64,7 @@
     font-family: inherit;
     font-size: 16px;
     padding: 20px 25px;
-    text-align: center;
+    text-align: left;
     width: inherit;
 
     @media screen and (max-width: $terra-medium-breakpoint) {
@@ -94,9 +89,8 @@
     }
   }
 
-  .profile-text-padding {
-    padding-left: 10px;
-    text-align: left;
+  .avatar {
+    padding-right: 10px;
   }
 
   .link-text-style {

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
@@ -2,12 +2,14 @@
 
 :local {
   .profile {
-    background: inherit;
+    background: none;
     bottom: 0;
-    height: auto;
-    left: 0;
     position: fixed;
-    width: inherit;
+    width: var(--terra-consumer--profile-width, $terra-consumer--nav-container-width);
+
+    @media screen and (max-width: $terra-tiny-breakpoint) {
+      width: 100%;
+    }
 
     @media screen and (max-width: $terra-medium-breakpoint) {
       background: inherit;
@@ -75,6 +77,7 @@
       background: inherit;
       color: var(--terra-consumer--desktop-nav-profile-button-color, #3d3d3d);
       cursor: pointer;
+      text-decoration: underline;
       @media screen and (max-width: $terra-medium-breakpoint) {
         color: var(--terra-consumer--mobile-nav-profile-button-color, #fff);
       }

--- a/packages/terra-consumer-nav/src/i18n/translations/messages.json
+++ b/packages/terra-consumer-nav/src/i18n/translations/messages.json
@@ -2,7 +2,7 @@
 	"en-US": {
 		"nav_help": "Help",
 		"nav_profile_title": "Settings",
+		"nav_signin": "Sign In",
 		"nav_signout": "Sign Out"
 	}
 }
-

--- a/packages/terra-consumer-nav/tests/jest/Nav.test.jsx
+++ b/packages/terra-consumer-nav/tests/jest/Nav.test.jsx
@@ -16,17 +16,19 @@ const testData = {
     altText: 'test',
     isCard: false,
   },
-  profileLinks: [{
-    text: 'Account',
-    url: 'http://localhost:8080/',
+  profile: {
+    profileLinks: [{
+      text: 'Account',
+      url: 'http://localhost:8080/',
+    },
+    {
+      text: 'Notifications',
+      url: 'http://localhost:8080/',
+    }],
+    userName: 'John Snow',
+    profileId: 'profile-popup-button',
+    signoutUrl: 'http://localhost:8080/',
   },
-  {
-    text: 'Notifications',
-    url: 'http://localhost:8080/',
-  }],
-  userName: 'John Snow',
-  profileId: 'profile-popup-button',
-  signoutUrl: 'http://localhost:8080/',
   isMobileNavOpen: false,
   onRequestClose: () => {},
 };
@@ -41,8 +43,8 @@ describe('Nav', () => {
   });
 
   // Structure Tests
-  it('should have the class nav', () => {
+  it('should have the id terra-consumer-nav', () => {
     const wrapper = shallow(defaultRender);
-    expect(wrapper.prop('className')).toContain('nav');
+    expect(wrapper.prop('id')).toContain('terra-consumer-nav');
   });
 });

--- a/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
@@ -2,12 +2,11 @@
 
 exports[`Nav should render a default component 1`] = `
 <div
-  className="nav"
+  id="terra-consumer-nav"
 >
   <div
     aria-hidden={true}
     className="nav"
-    profileId="profile-popup-button"
   >
     <Button
       className="close-button"
@@ -49,10 +48,9 @@ exports[`Nav should render a default component 1`] = `
       }
     />
     <InjectIntl(UserProfile)
-      avatar={null}
       handleClick={[Function]}
       id="profile-popup-button"
-      name="John Snow"
+      profileId="profile-popup-button"
       profileLinks={
         Array [
           Object {
@@ -66,6 +64,7 @@ exports[`Nav should render a default component 1`] = `
         ]
       }
       signoutUrl="http://localhost:8080/"
+      userName="John Snow"
     />
   </div>
   <ResponsiveElement

--- a/packages/terra-consumer-nav/tests/jest/components/NavHelp.test.jsx
+++ b/packages/terra-consumer-nav/tests/jest/components/NavHelp.test.jsx
@@ -9,7 +9,7 @@ const helpItems = [
   {
     text: 'Technical Questions',
     url: 'http://localhost:8080/',
-    icon: (<IconOutlineQuestionMark height={16} width={16} />),
+    icon: (<IconOutlineQuestionMark />),
     children: [{
       text: 'Need help using this portal or need to report an issue? Contact the support team at 123-xxx-xxxx',
       uri: 'http://localhost:8080/',
@@ -18,7 +18,7 @@ const helpItems = [
   {
     text: 'Get Support ID',
     url: 'http://localhost:8080/',
-    icon: (<IconOutlineQuestionMark height={16} width={16} />),
+    icon: (<IconOutlineQuestionMark />),
     children: [],
   },
 ];

--- a/packages/terra-consumer-nav/tests/jest/components/NavLogo.test.jsx
+++ b/packages/terra-consumer-nav/tests/jest/components/NavLogo.test.jsx
@@ -18,6 +18,11 @@ describe('Nav Logo', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
+  it('should render a div regardless of isCard when no url is provided', () => {
+    const wrapper = shallow(<NavLogo isCard altText="test" />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
   it('should apply custom classes', () => {
     const wrapper = shallow(<NavLogo {...testData} className="test-class" />);
     expect(wrapper).toMatchSnapshot();

--- a/packages/terra-consumer-nav/tests/jest/components/UserProfile.test.jsx
+++ b/packages/terra-consumer-nav/tests/jest/components/UserProfile.test.jsx
@@ -6,12 +6,12 @@ import UserProfile from '../../../src/components/user-profile/ProfileLinks';
 const profileLinks = [
   {
     text: 'Account',
-    icon: (<IconOutlineQuestionMark height={16} width={16} />),
+    icon: (<IconOutlineQuestionMark />),
     url: 'http://localhost:8080/',
   },
   {
     text: 'Notifications',
-    icon: (<IconOutlineQuestionMark height={16} width={16} />),
+    icon: (<IconOutlineQuestionMark />),
     url: 'http://localhost:8080/',
   },
 ];
@@ -21,10 +21,20 @@ describe('UserProfile', () => {
   it('should render a user profile with avatar,name and popup button', () => {
     const wrapper = shallow(<UserProfile
       profileLinks={profileLinks}
-      name="Frank Lampard"
+      name="Anthony Martial"
       avatar={<IconPerson />}
       signoutUrl="http://localhost:8080/"
     />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render a default avatar when none is provided', () => {
+    const wrapper = shallow(<UserProfile name="Test user" profileLinks={profileLinks} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render as a signin link when specified', () => {
+    const wrapper = shallow(<UserProfile isSignIn signinUrl="google.com" />);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelp.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelp.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`NavHelp button with pop/modal should render a button with IconInfo,labe
     Object {
       "nav_help": "Help",
       "nav_profile_title": "Settings",
+      "nav_signin": "Sign In",
       "nav_signout": "Sign Out",
     }
   }
@@ -23,9 +24,7 @@ exports[`NavHelp button with pop/modal should render a button with IconInfo,labe
               },
             ],
             "icon": <IconOutlineQuestionMark
-              height={16}
               viewBox="0 0 48 48"
-              width={16}
               xmlns="http://www.w3.org/2000/svg"
         />,
             "text": "Technical Questions",
@@ -34,9 +33,7 @@ exports[`NavHelp button with pop/modal should render a button with IconInfo,labe
           Object {
             "children": Array [],
             "icon": <IconOutlineQuestionMark
-              height={16}
               viewBox="0 0 48 48"
-              width={16}
               xmlns="http://www.w3.org/2000/svg"
         />,
             "text": "Get Support ID",

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
@@ -23,9 +23,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
         </div>
       }
       fitEnd={
-        <div
-          className="icon"
-        >
+        <div>
           <IconChevronDown
             className="icon"
             data-name="Layer 1"
@@ -36,9 +34,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
         </div>
       }
       fitStart={
-        <div
-          className="icon"
-        >
+        <div>
           <IconOutlineQuestionMark
             height={16}
             viewBox="0 0 48 48"
@@ -65,7 +61,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
     </Toggle>
   </Button>
   <Button
-    className="help-item help-item-border"
+    className="help-item"
     href="http://localhost:8080/"
     isBlock={false}
     isCompact={false}

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpPopup.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpPopup.test.jsx.snap
@@ -38,8 +38,12 @@ exports[`Popup should render a pop with title,close button and content 1`] = `
         variant="default"
       />
     </div>
-    <div>
-       This is a test content
+    <div
+      className="popup-body"
+    >
+      <div>
+         This is a test content
+      </div>
     </div>
   </div>
 </Popup>
@@ -61,8 +65,12 @@ exports[`Popup should render a popup without header(title & close button) 1`] = 
   targetRef={[Function]}
 >
   <div>
-    <div>
-       This is a test content
+    <div
+      className="popup-body"
+    >
+      <div>
+         This is a test content
+      </div>
     </div>
   </div>
 </Popup>

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavItem.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavItem.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`Nav Item as Toggler should render a nav as a toggle component 1`] = `
     className=""
   >
     <a
-      className="nav-item"
+      className="nav-item nav-item-link"
       href="#testPath"
     >
       <Arrange
@@ -34,7 +34,7 @@ exports[`Nav Item should apply custom classes 1`] = `
     className=""
   >
     <a
-      className="nav-item"
+      className="nav-item nav-item-link"
       href="#testPath"
     >
       <Arrange
@@ -60,7 +60,7 @@ exports[`Nav Item should render a default component 1`] = `
     className=""
   >
     <a
-      className="nav-item"
+      className="nav-item nav-item-link"
       href="#testPath"
     >
       <Arrange

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavItem.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavItem.test.jsx.snap
@@ -12,9 +12,10 @@ exports[`Nav Item as Toggler should render a nav as a toggle component 1`] = `
       href="#testPath"
     >
       <Arrange
+        align="center"
         fill={
           <div
-            className=""
+            className="nav-item-no-icon"
           >
             testIcon
           </div>
@@ -38,9 +39,10 @@ exports[`Nav Item should apply custom classes 1`] = `
       href="#testPath"
     >
       <Arrange
+        align="center"
         fill={
           <div
-            className=""
+            className="nav-item-no-icon"
           >
             testIcon
           </div>
@@ -64,9 +66,10 @@ exports[`Nav Item should render a default component 1`] = `
       href="#testPath"
     >
       <Arrange
+        align="center"
         fill={
           <div
-            className=""
+            className="nav-item-no-icon"
           >
             testIcon
           </div>

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavLogo.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavLogo.test.jsx.snap
@@ -35,3 +35,14 @@ exports[`Nav Logo should render a default component 1`] = `
   />
 </div>
 `;
+
+exports[`Nav Logo should render a div regardless of isCard when no url is provided 1`] = `
+<div
+  className="logo-container"
+>
+  <img
+    alt="test"
+    className="img"
+  />
+</div>
+`;

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/UserProfile.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/UserProfile.test.jsx.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`UserProfile should render a default avatar when none is provided 1`] = `
+<div
+  name="Test user"
+  profileLinks={
+    Array [
+      Object {
+        "icon": <IconOutlineQuestionMark
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+    />,
+        "text": "Account",
+        "url": "http://localhost:8080/",
+      },
+      Object {
+        "icon": <IconOutlineQuestionMark
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+    />,
+        "text": "Notifications",
+        "url": "http://localhost:8080/",
+      },
+    ]
+  }
+/>
+`;
+
 exports[`UserProfile should render a user profile with avatar,name and popup button 1`] = `
 <div
   avatar={
@@ -9,14 +35,12 @@ exports[`UserProfile should render a user profile with avatar,name and popup but
       xmlns="http://www.w3.org/2000/svg"
     />
   }
-  name="Frank Lampard"
+  name="Anthony Martial"
   profileLinks={
     Array [
       Object {
         "icon": <IconOutlineQuestionMark
-          height={16}
           viewBox="0 0 48 48"
-          width={16}
           xmlns="http://www.w3.org/2000/svg"
     />,
         "text": "Account",
@@ -24,9 +48,7 @@ exports[`UserProfile should render a user profile with avatar,name and popup but
       },
       Object {
         "icon": <IconOutlineQuestionMark
-          height={16}
           viewBox="0 0 48 48"
-          width={16}
           xmlns="http://www.w3.org/2000/svg"
     />,
         "text": "Notifications",
@@ -35,5 +57,12 @@ exports[`UserProfile should render a user profile with avatar,name and popup but
     ]
   }
   signoutUrl="http://localhost:8080/"
+/>
+`;
+
+exports[`UserProfile should render as a signin link when specified 1`] = `
+<div
+  isSignIn={true}
+  signinUrl="google.com"
 />
 `;

--- a/packages/terra-consumer-nav/tests/nightwatch/DefaultNav.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/DefaultNav.jsx
@@ -93,7 +93,6 @@ const DefaultNav = () => {
         },
       ],
       userName: 'John Snow',
-      avatar: (<IconPerson />),
       signoutUrl: 'http://localhost:8080/',
     },
 

--- a/packages/terra-consumer-nav/tests/nightwatch/DefaultNav.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/DefaultNav.jsx
@@ -5,7 +5,6 @@ import IconPerson from 'terra-icon/lib/icon/IconPerson';
 import IconOutlineQuestionMark from 'terra-consumer-icon/lib/icon/IconOutlineQuestionMark';
 import Layout from './Layout';
 
-
 const DefaultNav = () => {
   const props = {
     nav: {
@@ -31,10 +30,13 @@ const DefaultNav = () => {
       ],
       navItems: [
         {
+          url: 'localhost:8080',
+          text: 'Home',
+        },
+        {
           url: '?react_perf#/tests/nav-tests/default',
           text: 'Dashboard',
           icon: <IconPerson />,
-          isActive: false,
         },
         {
           text: 'Messaging',
@@ -50,34 +52,58 @@ const DefaultNav = () => {
             {
               url: '#sent',
               text: 'Sent',
-              isActive: false,
               badgeValue: 1,
             },
           ],
         },
         {
-          url: '/?react_perf',
           text: 'Health Record',
-          isActive: false,
-        },
-        {
-          text: 'See test data',
+          badgeValue: 0,
+          icon: <IconPerson />,
           subItems: [
             {
-              url: '#inbox2',
-              text: 'Inbox',
-              isActive: false,
+              url: '#health',
+              text: 'Health',
+              icon: <IconPerson />,
             },
             {
-              url: '#sent2',
-              text: 'Sent',
-              isActive: false,
+              url: '#record',
+              text: 'Record',
+              icon: <IconPerson />,
+            },
+          ],
+        },
+        {
+          text: 'Test Data',
+          subItems: [
+            {
+              url: '#test',
+              text: 'Test',
+              icon: <IconPerson />,
+            },
+            {
+              url: '#data',
+              text: 'Data',
+              icon: <IconPerson />,
+            },
+          ],
+        },
+        {
+          text: 'More Tests',
+          subItems: [
+            {
+              url: '#more',
+              text: 'More',
+            },
+            {
+              url: '#tests',
+              text: 'Tests',
             },
           ],
         },
       ],
       logo: {
-        url: 'http://placeholder.pics/svg/250x100/FF0606-FFFFFF',
+        // url: 'http://placeholder.pics/svg/250x100/FF0606-FFFFFF',
         altText: 'Placeholder logo',
         isCard: true,
       },

--- a/packages/terra-consumer-nav/tests/nightwatch/DefaultNav.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/DefaultNav.jsx
@@ -39,6 +39,7 @@ const DefaultNav = () => {
         {
           text: 'Messaging',
           badgeValue: 2,
+          icon: <IconPerson />,
           subItems: [
             {
               url: '#inbox',
@@ -80,20 +81,24 @@ const DefaultNav = () => {
         altText: 'Placeholder logo',
         isCard: true,
       },
-      profileLinks: [
-        {
-          text: 'Account',
-          icon: (<IconOutlineQuestionMark />),
-          url: 'http://localhost:8080/',
-        },
-        {
-          text: 'Notifications',
-          icon: (<IconOutlineQuestionMark />),
-          url: 'http://localhost:8080/',
-        },
-      ],
-      userName: 'John Snow',
-      signoutUrl: 'http://localhost:8080/',
+      profile: {
+        profileLinks: [
+          {
+            text: 'Account',
+            icon: (<IconOutlineQuestionMark />),
+            url: 'http://localhost:8080/',
+          },
+          {
+            text: 'Notifications',
+            icon: (<IconOutlineQuestionMark />),
+            url: 'http://localhost:8080/',
+          },
+        ],
+        // comment out userName to see signin
+        userName: 'John Snow',
+        signinUrl: 'http://localhost:8080/',
+        signoutUrl: 'http://localhost:8080/',
+      },
     },
 
     helpItems: [
@@ -110,7 +115,10 @@ const DefaultNav = () => {
         text: 'Get Support ID',
         url: 'http://localhost:8080/',
         icon: (<IconOutlineQuestionMark />),
-        children: [],
+        children: [{
+          text: 'Need help using this portal or need to report an issue? Contact the support team at 123-xxx-xxxx',
+          url: 'http://localhost:8080/',
+        }],
       },
     ],
     locale: 'en-US',

--- a/packages/terra-consumer-nav/tests/nightwatch/Layout.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/Layout.jsx
@@ -59,12 +59,8 @@ class Layout extends React.Component {
             <button className={cx('nav-burger')} onClick={this.toggleNav}>
               <IconMenu />
             </button>
-            {/* Added a div to test the HelpButton relative to page content */}
             <div style={{ background: '#fff', height: '100%', width: 'inherit' }}>I am in the main content</div>
-            <div className={cx('footer')}>
-              <NavHelp helpNavs={helpItems} id="nav-help-button" />
-            </div>
-            <NavHelp className={cx('help-button-desktop')} helpNavs={helpItems} id="nav-help-button" />
+            <NavHelp helpNavs={helpItems} id="nav-help-button" className={cx('help-button')} />
           </div>
         </div>
       </I18nProvider>

--- a/packages/terra-consumer-nav/tests/nightwatch/Layout.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/Layout.jsx
@@ -59,8 +59,12 @@ class Layout extends React.Component {
             <button className={cx('nav-burger')} onClick={this.toggleNav}>
               <IconMenu />
             </button>
+            {/* Added a div to test the HelpButton relative to page content */}
             <div style={{ background: '#fff', height: '100%', width: 'inherit' }}>I am in the main content</div>
-            <NavHelp helpNavs={helpItems} id="nav-help-button" className={cx('help-button')} />
+            <div className={cx('footer')}>
+              <NavHelp helpNavs={helpItems} id="nav-help-button" />
+            </div>
+            <NavHelp className={cx('help-button-desktop')} helpNavs={helpItems} id="nav-help-button" />
           </div>
         </div>
       </I18nProvider>

--- a/packages/terra-consumer-nav/tests/nightwatch/Layout.scss
+++ b/packages/terra-consumer-nav/tests/nightwatch/Layout.scss
@@ -3,6 +3,8 @@
 :local {
   body {
     font-family: 'Roboto', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     margin: 0;
   }
 

--- a/packages/terra-consumer-nav/tests/nightwatch/Layout.scss
+++ b/packages/terra-consumer-nav/tests/nightwatch/Layout.scss
@@ -7,38 +7,37 @@
   }
 
   .layout {
-    background: linear-gradient(#ddd, #999);
+    background: #eee;
     display: flex;
-    font-size: 14px;
-    height: 100vh;
-    left: 0;
+    max-height: 100vh;
     max-width: 100vw;
     overflow: hidden;
-    padding-top: 30px;
-    position: absolute;
-    top: 0;
-    width: 100vw;
   }
 
   .nav-container {
-    width: $terra-consumer--nav-container-width;
-    @media screen and (max-width: $terra-medium-breakpoint) {
-      margin-top: -30px;
+    color: #000;
+    max-width: $terra-consumer--nav-container-width;
+    padding-top: 30px;
+    z-index: 200;
+
+    @media (max-width: $terra-medium-breakpoint) {
+      padding-top: 0;
     }
   }
 
   .main-container {
-    height: 100vh;
+    bottom: 0;
     left: $terra-consumer--nav-container-width;
-    max-width: calc(100vw - #{$terra-consumer--nav-container-width});
-    overflow: scroll;
+    max-height: 100vh;
+    overflow: auto;
+    padding-right: 20px;
     position: absolute;
-    text-align: left;
+    top: 5px;
     width: calc(100vw - #{$terra-consumer--nav-container-width});
-    @media screen and (max-width: $terra-medium-breakpoint) {
-      left: 20px;
-      max-width: 100vw;
-      width: 100vw;
+    @media (max-width: $terra-medium-breakpoint) {
+      left: 0;
+      padding-left: 20px;
+      width: 100%;
     }
   }
 
@@ -62,27 +61,14 @@
     }
   }
 
-  .footer {
-    padding-bottom: 30px;
-    padding-right: 40px;
-    padding-top: 20px;
+  .help-button {
+    margin: 15px 0;
     text-align: right;
-    visibility: hidden;
-    width: inherit;
 
-    @media screen and (max-width: $terra-medium-breakpoint) {
-      visibility: visible;
-    }
-  }
-
-
-  .help-button-desktop {
-    bottom: 15px;
-    position: fixed;
-    right: 15px;
-
-    @media screen and (max-width: $terra-medium-breakpoint) {
-      display: none;
+    @media screen and (min-width: $terra-medium-breakpoint) {
+      bottom: 0;
+      position: fixed;
+      right: 15px;
     }
   }
 }

--- a/packages/terra-consumer-nav/tests/nightwatch/Layout.scss
+++ b/packages/terra-consumer-nav/tests/nightwatch/Layout.scss
@@ -7,37 +7,34 @@
   }
 
   .layout {
-    background: #eee;
+    background: linear-gradient(#ddd, #999);
     display: flex;
-    max-height: 100vh;
+    font-size: 14px;
+    height: 100vh;
+    left: 0;
     max-width: 100vw;
     overflow: hidden;
+    position: absolute;
+    top: 0;
+    width: 100vw;
   }
 
   .nav-container {
-    color: #000;
-    max-width: $terra-consumer--nav-container-width;
-    padding-top: 30px;
-    z-index: 200;
-
-    @media (max-width: $terra-medium-breakpoint) {
-      padding-top: 0;
-    }
+    width: $terra-consumer--nav-container-width;
   }
 
   .main-container {
-    bottom: 0;
+    height: 100vh;
     left: $terra-consumer--nav-container-width;
-    max-height: 100vh;
-    overflow: auto;
-    padding-right: 20px;
+    max-width: calc(100vw - #{$terra-consumer--nav-container-width});
+    overflow: scroll;
     position: absolute;
-    top: 5px;
+    text-align: left;
     width: calc(100vw - #{$terra-consumer--nav-container-width});
-    @media (max-width: $terra-medium-breakpoint) {
-      left: 0;
-      padding-left: 20px;
-      width: 100%;
+    @media screen and (max-width: $terra-medium-breakpoint) {
+      left: 20px;
+      max-width: 100vw;
+      width: 100vw;
     }
   }
 
@@ -61,14 +58,27 @@
     }
   }
 
-  .help-button {
-    margin: 15px 0;
+  .footer {
+    padding-bottom: 30px;
+    padding-right: 40px;
+    padding-top: 20px;
     text-align: right;
+    visibility: hidden;
+    width: inherit;
 
-    @media screen and (min-width: $terra-medium-breakpoint) {
-      bottom: 0;
-      position: fixed;
-      right: 15px;
+    @media screen and (max-width: $terra-medium-breakpoint) {
+      visibility: visible;
+    }
+  }
+
+
+  .help-button-desktop {
+    bottom: 15px;
+    position: fixed;
+    right: 15px;
+
+    @media screen and (max-width: $terra-medium-breakpoint) {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
### Summary
Changes made to profile link to allow for signin as well as ui fixes across the navigation component.

### Added
- Profile now has option to display sign-in link.
- Profile now overlays items on long navigation lists.

### Changed
- Minor UI fixes.
- Font antialiased fixes for chrome/firefox.
- Hover effects for nav-items (mobile/desktop)
- Scrolling content on help popup no longer scrolls title.
- Removed id as prop requirement for help/profile.
- Multiple help togglers do not open simultaneously, although there can be more than one open at a time.
Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE

https://terra-consumer-pr-21.herokuapp.com/static/#/tests/nav-tests/default