### PR TITLE
fix new tab working 

### DIFF
--- a/packages/terra-consumer-layout/tests/nightwatch/DexLayout.jsx
+++ b/packages/terra-consumer-layout/tests/nightwatch/DexLayout.jsx
@@ -109,6 +109,11 @@ const data = {
           text: 'Notifications',
           url: 'http://localhost:8080/',
         },
+        {
+        url: 'http://google.com',
+        text: 'Google External',
+        target: '_blank',
+      },
       ],
       // comment out userName to see signin
       userName: 'John Snow',
@@ -134,6 +139,11 @@ const data = {
         url: 'http://localhost:8080/',
       }],
     },
+          {
+        url: 'http://google.com',
+        text: 'Google External',
+        target: '_blank',
+      },
   ],
 };
 

--- a/packages/terra-consumer-layout/tests/nightwatch/DexLayout.jsx
+++ b/packages/terra-consumer-layout/tests/nightwatch/DexLayout.jsx
@@ -88,6 +88,11 @@ const data = {
           },
         ],
       },
+      {
+        url: 'http://google.com',
+        text: 'Google External',
+        target: '_blank',
+      },
     ],
     logo: {
       url: 'http://www.vectortemplates.com/raster/batman-logo-big.gif',

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -61,6 +61,7 @@ class NavHelpContent extends React.Component {
             className={cx('help-item')}
             key={content.text}
             url={content.url}
+            target={content.target}
             isExternal={content.isExternal}
           >
             <Arrange

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItems.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItems.jsx
@@ -66,6 +66,7 @@ class NavItems extends Component {
           url={element.url}
           text={element.text}
           icon={element.icon}
+          target={element.target}
           isActive={element.isActive}
           isExternal={element.isExternal}
           badgeValue={element.badgeValue}

--- a/packages/terra-consumer-nav/src/components/user-profile/ProfileLinks.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/ProfileLinks.jsx
@@ -29,6 +29,7 @@ const ProfileLinks = ({
       <SmartLink
         key={linkItem.text}
         url={linkItem.url}
+        target={linkItem.target}
         isExternal={linkItem.isExternal}
         className={cx('link', 'profile-item-border')}
       >{linkItem.text}


### PR DESCRIPTION
### Summary
When target was set to "_blank" was not opening a new tab, that was because it wasn't being passed in the smartlinks