### PR TITLE
Added skip-to-main-content anchor

### DIFF
--- a/packages/terra-consumer-layout/package.json
+++ b/packages/terra-consumer-layout/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "prop-types": "^15.5.8",
+    "react-intl": "^2.3.0",
     "terra-base": "^1.0.0",
     "terra-consumer-icon": "^1.2.0",
     "terra-consumer-nav": "0.1.0-BETA.4",

--- a/packages/terra-consumer-layout/src/Layout.jsx
+++ b/packages/terra-consumer-layout/src/Layout.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import Nav from 'terra-consumer-nav';
 import IconMenu from 'terra-icon/lib/icon/IconMenu';
+import { injectIntl, intlShape } from 'react-intl';
 import styles from './Layout.scss';
 
 const cx = classNames.bind(styles);
@@ -10,6 +11,10 @@ const cx = classNames.bind(styles);
 const propTypes = {
   nav: PropTypes.object.isRequired,
   helpItems: PropTypes.array,
+  /**
+   * Injected react-intl formatting api
+   */
+  intl: intlShape.isRequired,
   children: PropTypes.node.isRequired,
 };
 
@@ -30,21 +35,28 @@ class Layout extends React.Component {
   }
 
   render() {
-    const { nav, helpItems, ...customProps } = this.props;
+    const { nav, helpItems, intl, ...customProps } = this.props;
     return (
-      <div className={cx('layout', customProps.className)} {...customProps}>
-        <div className={cx('nav-container')}>
-          <Nav
-            {...nav}
-            isMobileNavOpen={this.state.isMobileNavOpen}
-            onRequestClose={this.toggleNav}
-          />
+      <div>
+        <div className={cx('skip-container')}>
+          <a className={cx('skip-to-main-content')} href="#main-container" id="skip-maincontent-link">
+            {intl.formatMessage({ id: 'Terra.Consumer.Layout.skipcontent' })}
+          </a>
         </div>
-        <main className={cx('main-container')}>
-          <button className={cx('nav-burger')} onClick={this.toggleNav}><IconMenu /></button>
-          {this.props.children}
-          <Nav.Help className={cx('help-button')} helpNavs={helpItems} id="nav-help-button" />
-        </main>
+        <div className={cx('layout', customProps.className)} {...customProps}>
+          <div className={cx('nav-container')}>
+            <Nav
+              {...nav}
+              isMobileNavOpen={this.state.isMobileNavOpen}
+              onRequestClose={this.toggleNav}
+            />
+          </div>
+          <main id="main-container" className={cx('main-container')}>
+            <button className={cx('nav-burger')} onClick={this.toggleNav}><IconMenu /></button>
+            {this.props.children}
+            <Nav.Help className={cx('help-button')} helpNavs={helpItems} id="nav-help-button" />
+          </main>
+        </div>
       </div>
     );
   }
@@ -52,4 +64,4 @@ class Layout extends React.Component {
 
 Layout.propTypes = propTypes;
 
-export default Layout;
+export default injectIntl(Layout);

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -88,4 +88,22 @@
       right: 15px;
     }
   }
+  .skip-to-main-content {
+    height: 1px;
+    left: -1000px;
+    overflow: hidden;
+    position: absolute;
+    top: auto;
+    width: 1px;
+
+    &:focus {
+      height: auto;
+      position: static;
+      width: auto;
+    }
+  }
+
+ .skip-container {
+   text-align: center;
+  }
 }

--- a/packages/terra-consumer-layout/translations/en-GB.json
+++ b/packages/terra-consumer-layout/translations/en-GB.json
@@ -1,0 +1,3 @@
+{
+  "Terra.Consumer.Layout.skipcontent": "Skip to Main Content"
+}

--- a/packages/terra-consumer-layout/translations/en-US.json
+++ b/packages/terra-consumer-layout/translations/en-US.json
@@ -1,0 +1,3 @@
+{
+  "Terra.Consumer.Layout.skipcontent": "Skip to Main Content"
+}

--- a/packages/terra-consumer-layout/translations/en.json
+++ b/packages/terra-consumer-layout/translations/en.json
@@ -1,0 +1,3 @@
+{
+  "Terra.Consumer.Layout.skipcontent": "Skip to Main Content"
+}


### PR DESCRIPTION
### Summary
Added anchor to skip the navigation links and directly go to the main content.
**Note:** One issue I just noticed that after the anchor is set to internal content(#main-content)  the browser URL location is set to http://localhost:8080/#/main-container  which should be http://localhost:8080/#/tests/layout-tests/dex#main-content" . Trying to add an **onlick** action to concatenate current link with an internal(main-content) link. 

![skip2main](https://user-images.githubusercontent.com/21693381/29987904-7f167404-8f38-11e7-931e-c0446f979c4e.gif)


Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
