### PR TITLE
fix IE nav 100% height

### DIFF
--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -11,6 +11,7 @@ ChangeLog
 - mobile nav now matches styles of desktop nav
 - when nav is open on mobile, the main content can no longer scroll freely
 - Updated terra-core packages
+- Fix nav 100% height in IE
 
 ### Removed
 - Removed QuickLinks

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -27,6 +27,7 @@
     background: var(--terra-consumer-nav-background, rgba(255, 255, 255, 0.25));
     color: var(--terra-consumer-nav-text-color);
     height: 100%;
+    min-height: 100vh;
     overflow-y: auto;
     padding-bottom: 60px;
     padding-top: var(--terra-consumer-nav-padding-top, 25px);

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -26,7 +26,11 @@
   .nav {
     background: var(--terra-consumer-nav-background, rgba(255, 255, 255, 0.25));
     color: var(--terra-consumer-nav-text-color);
+    /* nav is relative positioned and its height depends on the height of the main content next to it.
+     * height: 100% makes sure nav height >= content height
+    */
     height: 100%;
+    // makes sure nav cover the window height on IE if the content next to it is shorter than window height
     min-height: 100vh;
     overflow-y: auto;
     padding-bottom: 60px;

--- a/packages/terra-consumer-site/webpack.config.js
+++ b/packages/terra-consumer-site/webpack.config.js
@@ -15,7 +15,7 @@ const rtl = require('postcss-rtl');
 module.exports = {
   entry: {
     'babel-polyfill': 'babel-polyfill',
-    'terra-core': path.resolve(path.join(__dirname, 'src', 'Index')),
+    'terra-consumer': path.resolve(path.join(__dirname, 'src', 'Index')),
   },
   module: {
     loaders: [{
@@ -79,7 +79,7 @@ module.exports = {
     new ExtractTextPlugin('[name]-[hash].css'),
     new HtmlWebpackPlugin({
       template: path.join(__dirname, 'src', 'index.html'),
-      chunks: ['babel-polyfill', 'terra-core'],
+      chunks: ['babel-polyfill', 'terra-consumer'],
     }),
     new I18nAggregatorPlugin({
       baseDirectory: __dirname,


### PR DESCRIPTION
### Summary
Jira: https://jira2.cerner.com/browse/PORTALDEV-36253
On IE nav height doesn't stretch to the window height:
<img width="572" alt="screen shot 2017-09-05 at 2 20 06 pm" src="https://user-images.githubusercontent.com/5943136/30123816-d2b5d42e-92f8-11e7-9d47-245c352f8790.png">

