### PR TITLE
Fix for Nav - mobile scroll for Firefox

### DIFF
--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -9,6 +9,7 @@ ChangeLog
 
 ### Changed
 - Changed logo height to be max of 120 px for both mobile and desktop
+- Fix scroll side nav in mobile in Firefox
 
 ------------------
 

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -9,7 +9,7 @@ ChangeLog
 
 ### Changed
 - Changed logo height to be max of 120 px for both mobile and desktop
-- Fix scroll side nav in mobile in Firefox
+- Fix scroll side nav in mobile in Firefox and IE
 
 ------------------
 

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -51,9 +51,11 @@
       overflow: auto;
       padding-top: var(--terra-consumer--mobile-nav-padding-top, 0);
       position: absolute;
+      
+      /*stylelint-disable function-url-quotes*/
       @-moz-document url-prefix() {
+        height: 80% !important;
         min-height: 93vh;
-        height:80% !important;
         overflow-y: auto;
       }
     }

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -42,21 +42,18 @@
     user-select: none;
     width: var(--terra-consumer-nav-width, 320px);
     z-index: 2;
-
     @media screen and (max-width: $terra-tiny-breakpoint) {
       width: 100vw;
     }
 
     @media screen and (max-width: $terra-medium-breakpoint) {
+      height: calc(100% - 60px) !important;
       overflow: auto;
       padding-top: var(--terra-consumer--mobile-nav-padding-top, 0);
       position: absolute;
-      
       /*stylelint-disable function-url-quotes*/
       @-moz-document url-prefix() {
-        height: 80% !important;
-        min-height: 93vh;
-        overflow-y: auto;
+        min-height: max-content;
       }
     }
   }

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -38,6 +38,7 @@
     overflow-y: auto;
     padding-bottom: 60px;
     padding-top: var(--terra-consumer-nav-padding-top, 25px);
+    position: relative;
     top: 0;
     user-select: none;
     width: var(--terra-consumer-nav-width, 320px);
@@ -49,7 +50,6 @@
     @media screen and (max-width: $terra-medium-breakpoint) {
       overflow: auto;
       padding-top: var(--terra-consumer--mobile-nav-padding-top, 0);
-      position: relative;
     }
   }
 

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -47,14 +47,9 @@
     }
 
     @media screen and (max-width: $terra-medium-breakpoint) {
-      height: calc(100% - 60px) !important;
       overflow: auto;
       padding-top: var(--terra-consumer--mobile-nav-padding-top, 0);
-      position: absolute;
-      /*stylelint-disable function-url-quotes*/
-      @-moz-document url-prefix() {
-        min-height: max-content;
-      }
+      position: relative;
     }
   }
 

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -51,6 +51,11 @@
       overflow: auto;
       padding-top: var(--terra-consumer--mobile-nav-padding-top, 0);
       position: absolute;
+      @-moz-document url-prefix() {
+        min-height: 93vh;
+        height:80% !important;
+        overflow-y: auto;
+      }
     }
   }
 


### PR DESCRIPTION
### Summary
When the screen is made small both vertically and horizontally, and there are lots of links (like the patient portal example) 2 links at the bottom don't show

Before:
![before_firefox_scroll](https://user-images.githubusercontent.com/17807360/30182566-414c7cde-93e5-11e7-8505-e185f6d42cf4.gif)

After:
![firefox_scroll](https://user-images.githubusercontent.com/17807360/30173633-55d87550-93c6-11e7-820f-d72fa16fb3f4.gif)

Thanks for contributing to Terra. 
@cerner/terra #