### PR TITLE
Close nav on select

### DIFF
--- a/packages/terra-consumer-layout/CHANGELOG.md
+++ b/packages/terra-consumer-layout/CHANGELOG.md
@@ -1,15 +1,18 @@
 ChangeLog
 =========
 
+# 0.1.0-BETA.2 - (September 07, 2017)
 
-.6 Beta
+### Added
+- Theme-able padding for main container
+- Ability to close open mobile nav by clicking escape key
+- Ability to close open mobile nav by tapping elsewhere on the screen.
+
+### Removed
+- Removed unneeded terra-consumer--nav-container-width variable
+
 -----------------
-Initial stable release
-9/6/17:
- - Removed uneeded terra-consumer--nav-container-width variable
- - Added themeable padding for main container
 
 # 0.1.0-BETA.1 - (September 06, 2017)
------------------
-Initial beta release for the layout component
 
+Initial beta release for the layout component

--- a/packages/terra-consumer-layout/package.json
+++ b/packages/terra-consumer-layout/package.json
@@ -36,7 +36,9 @@
     "terra-consumer-icon": "^1.2.1",
     "terra-consumer-nav": "^0.1.0-BETA.5",
     "terra-i18n": "^1.5.0",
-    "terra-icon": "^1.5.0"
+    "terra-icon": "^1.5.0",
+    "terra-overlay": "^1.7.0",
+    "terra-responsive-element": "^1.7.0"
   },
   "scripts": {
     "compile": "npm run compile:clean && npm run compile:build",

--- a/packages/terra-consumer-layout/src/Layout.jsx
+++ b/packages/terra-consumer-layout/src/Layout.jsx
@@ -30,7 +30,31 @@ class Layout extends React.Component {
     this.state = {
       isMobileNavOpen: false,
     };
+
     this.toggleNav = this.toggleNav.bind(this);
+    this.setReference = this.setReference.bind(this);
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+  }
+
+  // Add event listener for clicks when component mounts
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleClickOutside);
+  }
+
+  // Remove event listener before breakdown of react component
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleClickOutside);
+  }
+
+  // set reference node without document.getElementById or ReactDOM
+  setReference(node) {
+    this.referenceNode = node;
+  }
+
+  handleClickOutside(event) {
+    if (this.referenceNode && !this.referenceNode.contains(event.target) && this.state.isMobileNavOpen) {
+      this.toggleNav();
+    }
   }
 
   toggleNav() {
@@ -49,11 +73,13 @@ class Layout extends React.Component {
           </a>
         </div>
         <div className={cx('layout', customProps.className)} {...customProps}>
-          <Nav
-            {...nav}
-            isMobileNavOpen={this.state.isMobileNavOpen}
-            onRequestClose={this.toggleNav}
-          />
+          <div ref={this.setReference}>
+            <Nav
+              {...nav}
+              isMobileNavOpen={this.state.isMobileNavOpen}
+              onRequestClose={this.toggleNav}
+            />
+          </div>
           <main id="main-container" className={cx('main-container', this.state.isMobileNavOpen && 'nav-open')}>
             <Nav.Burger className={cx('nav-burger')} handleClick={this.toggleNav} />
             {this.props.children}

--- a/packages/terra-consumer-layout/src/Layout.jsx
+++ b/packages/terra-consumer-layout/src/Layout.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames/bind';
 import Nav from 'terra-consumer-nav';
+import ResponsiveElement from 'terra-responsive-element';
+import Overlay from 'terra-overlay';
 import { injectIntl, intlShape } from 'react-intl';
 import styles from './Layout.scss';
 
@@ -32,35 +34,6 @@ class Layout extends React.Component {
     };
 
     this.toggleNav = this.toggleNav.bind(this);
-    this.setReference = this.setReference.bind(this);
-    this.captureEscapeKey = this.captureEscapeKey.bind(this);
-    this.handleClickOutside = this.handleClickOutside.bind(this);
-  }
-
-  componentDidMount() {
-    document.addEventListener('mousedown', this.handleClickOutside);
-    document.addEventListener('keypress', this.captureEscapeKey);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleClickOutside);
-    document.removeEventListener('keypress', this.captureEscapeKey);
-  }
-
-  setReference(node) {
-    this.referenceNode = node;
-  }
-
-  captureEscapeKey(event) {
-    if (event.keyCode === 27 && this.state.isMobileNavOpen) {
-      this.toggleNav();
-    }
-  }
-
-  handleClickOutside(event) {
-    if (this.state.isMobileNavOpen && this.referenceNode && !this.referenceNode.contains(event.target)) {
-      this.toggleNav();
-    }
   }
 
   toggleNav() {
@@ -71,6 +44,15 @@ class Layout extends React.Component {
 
   render() {
     const { nav, helpItems, intl, ...customProps } = this.props;
+    const overlay = (
+      <Overlay
+        onRequestClose={this.toggleNav}
+        isOpen={this.state.isMobileNavOpen}
+        backgroundStyle="clear"
+        isRelativeToContainer
+      />
+    );
+
     return (
       <div>
         <div className={cx('skip-container')}>
@@ -79,15 +61,13 @@ class Layout extends React.Component {
           </a>
         </div>
         <div className={cx('layout', customProps.className)} {...customProps}>
-          {/* Have to set the ref on an html element to use .contains() */}
-          <div ref={this.setReference}>
-            <Nav
-              {...nav}
-              isMobileNavOpen={this.state.isMobileNavOpen}
-              onRequestClose={this.toggleNav}
-            />
-          </div>
+          <Nav
+            {...nav}
+            isMobileNavOpen={this.state.isMobileNavOpen}
+            onRequestClose={this.toggleNav}
+          />
           <main id="main-container" className={cx('main-container', this.state.isMobileNavOpen && 'nav-open')}>
+            <ResponsiveElement defaultElement={overlay} responsiveTo="window" medium={<div />} />
             <Nav.Burger className={cx('nav-burger')} handleClick={this.toggleNav} />
             {this.props.children}
             <Nav.Help className={cx('help-button')} helpNavs={helpItems} id="nav-help-button" />

--- a/packages/terra-consumer-layout/src/Layout.jsx
+++ b/packages/terra-consumer-layout/src/Layout.jsx
@@ -33,26 +33,32 @@ class Layout extends React.Component {
 
     this.toggleNav = this.toggleNav.bind(this);
     this.setReference = this.setReference.bind(this);
+    this.captureEscapeKey = this.captureEscapeKey.bind(this);
     this.handleClickOutside = this.handleClickOutside.bind(this);
   }
 
-  // Add event listener for clicks when component mounts
   componentDidMount() {
     document.addEventListener('mousedown', this.handleClickOutside);
+    document.addEventListener('keypress', this.captureEscapeKey);
   }
 
-  // Remove event listener before breakdown of react component
   componentWillUnmount() {
     document.removeEventListener('mousedown', this.handleClickOutside);
+    document.removeEventListener('keypress', this.captureEscapeKey);
   }
 
-  // set reference node without document.getElementById or ReactDOM
   setReference(node) {
     this.referenceNode = node;
   }
 
+  captureEscapeKey(event) {
+    if (event.keyCode === 27 && this.state.isMobileNavOpen) {
+      this.toggleNav();
+    }
+  }
+
   handleClickOutside(event) {
-    if (this.referenceNode && !this.referenceNode.contains(event.target) && this.state.isMobileNavOpen) {
+    if (this.state.isMobileNavOpen && this.referenceNode && !this.referenceNode.contains(event.target)) {
       this.toggleNav();
     }
   }
@@ -73,6 +79,7 @@ class Layout extends React.Component {
           </a>
         </div>
         <div className={cx('layout', customProps.className)} {...customProps}>
+          {/* Have to set the ref on an html element to use .contains() */}
           <div ref={this.setReference}>
             <Nav
               {...nav}

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -43,16 +43,6 @@
     }
   }
 
-  .overlay-container {
-    display: none;
-    height: 100%;
-    width: 100%;
-
-    @media screen and (max-width: $terra-medium-breakpoint) {
-      display: block;
-    }
-  }
-
   .nav-burger {
     display: block;
     font-size: 20px;

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -38,6 +38,7 @@
     .nav-open.main-container {
       overflow: hidden;
       position: fixed;
+      width: 100%;
     }
   }
 

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -29,6 +29,7 @@
 
   .main-container {
     flex-grow: 1;
+    min-height: 100vh;
     padding: var(--terra-consumer-layout-padding, 10px);
     text-align: left;
     white-space: break-word;
@@ -39,6 +40,16 @@
       overflow: hidden;
       position: fixed;
       width: 100%;
+    }
+  }
+
+  .overlay-container {
+    display: none;
+    height: 100%;
+    width: 100%;
+
+    @media screen and (max-width: $terra-medium-breakpoint) {
+      display: block;
     }
   }
 

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -29,7 +29,7 @@
 
   .main-container {
     flex-grow: 1;
-    min-height: 100vh;
+    min-height: 100%;
     padding: var(--terra-consumer-layout-padding, 10px);
     text-align: left;
     white-space: break-word;

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -6,6 +6,7 @@ ChangeLog
 ### Added
 - Added a Nav 'Hamburger' Button to be used as the button to open the nav in mobile view.
 - Added the ability to have toggle content in profile links.
+- Added functionality to close nav when a link from the nav is selected by the user.
 
 ### Changed
 - Changed logo height to be max of 120 px for both mobile and desktop

--- a/packages/terra-consumer-nav/src/Nav.jsx
+++ b/packages/terra-consumer-nav/src/Nav.jsx
@@ -129,7 +129,7 @@ class Nav extends React.Component {
         >
           <Button icon={<IconClose />} className={cx('close-button')} onClick={() => { onRequestClose(); }} />
           <NavLogo {...logo} />
-          <NavItems navItems={navItems} />
+          <NavItems navItems={navItems} handleClick={onRequestClose} />
           { willRenderProfile &&
             <UserProfile
               {...profile}

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -10,6 +10,7 @@
         background-attachment: fixed;
         background-size: cover;
         content: '';
+        height: 100%;
         position: absolute;
         top: 0;
         width: var(--terra-consumer-nav-width, 320px);

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
@@ -23,6 +23,10 @@ const propTypes = {
    */
   isOpen: PropTypes.bool,
   /**
+   * Function to be applied to the generated link.
+   */
+  handleClick: PropTypes.func,
+  /**
    * Items to be displayed within the toggler.
    */
   children: PropTypes.node,
@@ -44,6 +48,7 @@ const NavItem = ({
   handleToggle,
   isOpen,
   isExternal,
+  handleClick,
   children,
   ...customProps
 }) => {
@@ -80,6 +85,7 @@ const NavItem = ({
         target={target}
         isExternal={isExternal}
         activeClass={activeClass}
+        handleClick={handleClick}
         className={cx('link', customProps.className)}
       >
         {itemText}

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItems.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItems.jsx
@@ -19,6 +19,10 @@ const propTypes = {
       },
     ),
   ),
+  /**
+   * Function to be applied on all nav links, excluding toggle headers.
+  */
+  handleClick: PropTypes.func,
 };
 
 const defaultProps = {
@@ -45,14 +49,14 @@ class NavItems extends Component {
   }
 
   render() {
-    const { navItems, ...customProps } = this.props;
+    const { navItems, handleClick, ...customProps } = this.props;
 
     const content = navItems.map((element, i) => {
       let toggleProps = {};
       let subNavs = [];
       if (element.subItems) {
         // eslint-disable-next-line react/no-array-index-key
-        subNavs = element.subItems.map((item, index) => <NavItem key={index} {...item} />);
+        subNavs = element.subItems.map((item, index) => <NavItem key={index} {...item} handleClick={handleClick} />);
         toggleProps = {
           isOpen: this.state.openToggle === i,
           handleToggle: this.handleToggle,
@@ -70,6 +74,7 @@ class NavItems extends Component {
           isActive={element.isActive}
           isExternal={element.isExternal}
           badgeValue={element.badgeValue}
+          handleClick={handleClick}
           {...toggleProps}
         >
           {subNavs}

--- a/packages/terra-consumer-nav/src/components/smart-link/SmartLink.jsx
+++ b/packages/terra-consumer-nav/src/components/smart-link/SmartLink.jsx
@@ -7,12 +7,14 @@ const propTypes = {
   target: PropTypes.string,
   isExternal: PropTypes.bool,
   activeClass: PropTypes.string,
+  handleClick: PropTypes.func,
   children: PropTypes.node.isRequired,
 };
 
 const defaultProps = {
   isExternal: false,
   target: '_self',
+  handleClick: () => {},
 };
 
 const SmartLink = ({
@@ -20,17 +22,21 @@ const SmartLink = ({
   target,
   isExternal,
   activeClass,
+  handleClick,
   children,
   ...customProps
 }) => (
   (isExternal || target === '_blank') ?
-    <a {...customProps} target={target} href={url}>{children}</a> :
+    <a {...customProps} onClick={handleClick} target={target} href={url}>{children}</a> :
     <NavLink
       {...customProps}
       exact
       activeClassName={activeClass}
       to={url}
-    >{children}</NavLink>
+      onClick={handleClick}
+    >
+      {children}
+    </NavLink>
   );
 
 SmartLink.propTypes = propTypes;

--- a/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
@@ -32,6 +32,7 @@ exports[`Nav should render a default component 1`] = `
       url=""
     />
     <NavItems
+      handleClick={[Function]}
       navItems={
         Array [
           Object {

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
@@ -62,6 +62,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
   </Button>
   <SmartLink
     className="help-item"
+    handleClick={[Function]}
     isExternal={false}
     target="_self"
     url="http://localhost:8080/"

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavItem.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavItem.test.jsx.snap
@@ -7,6 +7,7 @@ exports[`Nav Item as Toggler should render a nav as a toggle component 1`] = `
   <SmartLink
     activeClass="active"
     className="link"
+    handleClick={[Function]}
     isExternal={false}
     target="_self"
     url="#testPath"
@@ -33,6 +34,7 @@ exports[`Nav Item should apply custom classes 1`] = `
   <SmartLink
     activeClass="active"
     className="link test-class"
+    handleClick={[Function]}
     isExternal={false}
     target="_self"
     url="#testPath"
@@ -59,6 +61,7 @@ exports[`Nav Item should render a default component 1`] = `
   <SmartLink
     activeClass="active"
     className="link"
+    handleClick={[Function]}
     isExternal={false}
     target="_self"
     url="#testPath"


### PR DESCRIPTION
### Summary

Added functionality within Layout to close nav when user clicks outside of it or presses the escape key.
Added functionality that closes mobile nav when a nav-link is selected.