### PR TITLE
fixes so we arent passing classes to the terra button which get overr…

### DIFF
--- a/packages/terra-consumer-layout/CHANGELOG.md
+++ b/packages/terra-consumer-layout/CHANGELOG.md
@@ -1,7 +1,7 @@
 ChangeLog
-=========
 
 # 0.1.0-BETA.2 - (September 08, 2017)
+-----------------
 
 ### Changed
  - Fixed the help-button alignment issue.
@@ -11,6 +11,7 @@ ChangeLog
 - Ability to close open mobile nav by clicking escape key
 - Ability to close open mobile nav by tapping elsewhere on the screen.
 - Sliding Nav
+- Made hamburger alight with main content
 
 ### Removed
 - Removed unused terra-consumer--nav-container-width variable

--- a/packages/terra-consumer-layout/src/Layout.jsx
+++ b/packages/terra-consumer-layout/src/Layout.jsx
@@ -70,7 +70,9 @@ class Layout extends React.Component {
           <main id="main-container" className={cx('main-container')}>
             <ResponsiveElement defaultElement={overlay} responsiveTo="window" medium={<div />} />
             <div className={cx('main-container-inner')}>
-              <Nav.Burger className={cx('nav-burger')} handleClick={this.toggleNav} />
+              <div className={cx('nav-burger')}>
+                <Nav.Burger handleClick={this.toggleNav} />
+              </div>
               <div className={cx('main-content')}>{this.props.children}</div>
               <Nav.Help className={cx('help-button')} helpNavs={helpItems} id="nav-help-button" />
             </div>

--- a/packages/terra-consumer-layout/tests/nightwatch/DexLayout.jsx
+++ b/packages/terra-consumer-layout/tests/nightwatch/DexLayout.jsx
@@ -127,11 +127,11 @@ const data = {
 export default () => (
   <AppShellExample useRouter>
     <Layout {...data}>
-      <Route exact path="/" render={() => <h1>Home, sweet home!</h1>} />
+      <Route exact path="/" render={() => <h1 style={{ color: 'white' }}>of Thrones more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content</h1>} />
       <Route exact path="/inbox" render={() => <h1>You have millions of unread messages</h1>} />
       <Route exact path="/sent" render={() => <h1>Opps, it is empty</h1>} />
       <Route exact path="/health" render={() => <h1>Game</h1>} />
-      <Route exact path="/record" render={() => <h1>of Thrones</h1>} />
+      <Route exact path="/record" render={() => <h1 style={{ color: 'white' }}>of Thrones more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content more content</h1>} />
     </Layout>
   </AppShellExample>
 );

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -16,6 +16,7 @@ ChangeLog
 - Made Nav and Nav-Container width consistent in all places used.
 - Fixed modal content scrolling issue.
 - Refactored NavLogo for flex width and added new styles to logo text
+- Put move hamburger button font size from layout scss here. Layout burger class just handles position now
 ------------------
 
 # 0.1.0-BETA.5 - (September 06, 2017)

--- a/packages/terra-consumer-nav/src/Nav.jsx
+++ b/packages/terra-consumer-nav/src/Nav.jsx
@@ -124,7 +124,9 @@ class Nav extends React.Component {
         id="terra-consumer-nav"
         className={cx('nav', { 'modal-open': this.state.isModalOpen }, customProps.className)}
       >
-        <Button icon={<IconClose />} className={cx('close-button')} onClick={() => { onRequestClose(); }} variant="link" />
+        <div className={cx('close-button-container')}>
+          <Button icon={<IconClose />} className={cx('close-button')} onClick={() => { onRequestClose(); }} variant="link" />
+        </div>
         <NavLogo {...logo} />
         <NavItems navItems={navItems} handleClick={onRequestClose} />
         <ResponsiveElement responsiveTo="window" defaultElement={defaultElement} medium={popup} />

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -32,29 +32,22 @@
     }
   }
 
-  .close-button {
+  .close-button-container {
     display: none;
-
+    margin-right: 15px;
+    margin-top: 15px;
+    padding: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
     @media screen and (max-width: $terra-medium-breakpoint) {
-      background: var(--terra-consumer-mobile-close-button-background, none);
-      border: 0;
-      color: var(--terra-consumer-mobile-close-button-color, #fff);
       display: block;
-      font-size: 16px;
-      line-height: 16px;
-      margin-right: 15px;
-      margin-top: 15px;
-      padding: 0;
-      position: absolute;
-      right: 0;
-      top: 0;
     }
+  }
 
-    &:hover,
-    &:focus {
-      background: var(--terra-consumer-mobile-close-button-hover-background, none);
-      border-radius: 3px;
-      color: var(--terra-consumer-mobile-close-button-hover-color, #ccc);
-    }
+  .close-button {
+    color: var(--terra-consumer-mobile-close-button-color, #fff) !important;
+    font-size: 16px !important;
+    line-height: 16px !important;
   }
 }

--- a/packages/terra-consumer-nav/src/components/nav-burger-button/NavBurgerButton.scss
+++ b/packages/terra-consumer-nav/src/components/nav-burger-button/NavBurgerButton.scss
@@ -6,6 +6,7 @@
     border: var(--terra-consumer-burger-border, 0);
     box-shadow: var(--terra-consumer-burger-box-shadow, 0);
     color: var(--terra-consumer-burger-color, #fff);
+    font-size: 20px;
 
     &:hover,
     &:focus {

--- a/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
@@ -7,67 +7,43 @@ exports[`Nav should render a default component 1`] = `
   isMobileNavOpen={false}
 >
   <div
-    aria-hidden={true}
-    className="nav"
+    className="close-button-container"
   >
-    <div
-      className="close-button-container"
-    >
-      <Button
-        className="close-button"
-        icon={
-          <IconClose
-            data-name="Layer 1"
-            viewBox="0 0 48 48"
-            xmlns="http://www.w3.org/2000/svg"
-          />
-        }
-        isBlock={false}
-        isCompact={false}
-        isDisabled={false}
-        isReversed={false}
-        onClick={[Function]}
-        type="button"
-        variant="link"
-      />
-    </div>
-    <NavLogo
-      altText="test"
-      isCard={false}
-      url=""
-    />
-    <NavItems
-      handleClick={[Function]}
-      navItems={
-        Array [
-          Object {
-            "isActive": true,
-            "text": "test",
-            "url": "#test",
-          },
-        ]
+    <Button
+      className="close-button"
+      icon={
+        <IconClose
+          data-name="Layer 1"
+          viewBox="0 0 48 48"
+          xmlns="http://www.w3.org/2000/svg"
+        />
       }
-    />
-    <InjectIntl(UserProfile)
-      handleClick={[Function]}
-      id="profile-popup-button"
-      profileId="profile-popup-button"
-      profileLinks={
-        Array [
-          Object {
-            "text": "Account",
-            "url": "http://localhost:8080/",
-          },
-          Object {
-            "text": "Notifications",
-            "url": "http://localhost:8080/",
-          },
-        ]
-      }
-      signoutUrl="http://localhost:8080/"
-      userName="John Snow"
+      isBlock={false}
+      isCompact={false}
+      isDisabled={false}
+      isReversed={false}
+      onClick={[Function]}
+      type="button"
+      variant="link"
     />
   </div>
+  <NavLogo
+    altText="test"
+    isCard={false}
+    url=""
+  />
+  <NavItems
+    handleClick={[Function]}
+    navItems={
+      Array [
+        Object {
+          "isActive": true,
+          "text": "test",
+          "url": "#test",
+        },
+      ]
+    }
+  />
   <ResponsiveElement
     defaultElement={
       <Modal

--- a/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
@@ -6,40 +6,68 @@ exports[`Nav should render a default component 1`] = `
   id="terra-consumer-nav"
   isMobileNavOpen={false}
 >
-  <Button
-    className="close-button"
-    icon={
-      <IconClose
-        data-name="Layer 1"
-        viewBox="0 0 48 48"
-        xmlns="http://www.w3.org/2000/svg"
+  <div
+    aria-hidden={true}
+    className="nav"
+  >
+    <div
+      className="close-button-container"
+    >
+      <Button
+        className="close-button"
+        icon={
+          <IconClose
+            data-name="Layer 1"
+            viewBox="0 0 48 48"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        }
+        isBlock={false}
+        isCompact={false}
+        isDisabled={false}
+        isReversed={false}
+        onClick={[Function]}
+        type="button"
+        variant="link"
       />
-    }
-    isBlock={false}
-    isCompact={false}
-    isDisabled={false}
-    isReversed={false}
-    onClick={[Function]}
-    type="button"
-    variant="link"
-  />
-  <NavLogo
-    altText="test"
-    isCard={false}
-    url=""
-  />
-  <NavItems
-    handleClick={[Function]}
-    navItems={
-      Array [
-        Object {
-          "isActive": true,
-          "text": "test",
-          "url": "#test",
-        },
-      ]
-    }
-  />
+    </div>
+    <NavLogo
+      altText="test"
+      isCard={false}
+      url=""
+    />
+    <NavItems
+      handleClick={[Function]}
+      navItems={
+        Array [
+          Object {
+            "isActive": true,
+            "text": "test",
+            "url": "#test",
+          },
+        ]
+      }
+    />
+    <InjectIntl(UserProfile)
+      handleClick={[Function]}
+      id="profile-popup-button"
+      profileId="profile-popup-button"
+      profileLinks={
+        Array [
+          Object {
+            "text": "Account",
+            "url": "http://localhost:8080/",
+          },
+          Object {
+            "text": "Notifications",
+            "url": "http://localhost:8080/",
+          },
+        ]
+      }
+      signoutUrl="http://localhost:8080/"
+      userName="John Snow"
+    />
+  </div>
   <ResponsiveElement
     defaultElement={
       <Modal


### PR DESCRIPTION
…iden

### Summary
When passing class names to terra button, we are using them to override values like display hidden based on media queries. This works sometimes, but since they have the same specificity, if the terra-button css comes after it in our final bundle it wins and the buttons always show. To fix this display based css is moved to a container around the button, whilst the couple required css attributes get !important per @mhemesath 's recommendation

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
