### PR TITLE
Add sign out to profile

### DIFF
--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -7,6 +7,7 @@ ChangeLog
 - Added a Nav 'Hamburger' Button to be used as the button to open the nav in mobile view.
 - Added the ability to have toggle content in profile links.
 - Added functionality to close nav when a link from the nav is selected by the user.
+- Added functionality to profile to allow for the sign-out link to be the root element.
 
 ### Changed
 - Fix scroll side nav in mobile in Firefox and IE

--- a/packages/terra-consumer-nav/src/Nav.jsx
+++ b/packages/terra-consumer-nav/src/Nav.jsx
@@ -23,10 +23,7 @@ const propTypes = {
   /**
   * Object representing all the profile information
   */
-  profile: PropTypes.shape({
-    signinUrl: PropTypes.string,
-    avatar: PropTypes.element,
-  }),
+  profile: PropTypes.object,
   /**
    * An object defining the logo to be displayed
    */
@@ -133,7 +130,6 @@ class Nav extends React.Component {
             {...profile}
             id={profileId}
             handleClick={this.handleOpenProfile}
-            isSignIn={profile.signinUrl && !(profile.avatar || profile.userName)}
           />
         </div>
       </div>

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Arrange from 'terra-arrange';
 import classNames from 'classnames/bind';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import Button from 'terra-button';
 import IconEllipses from 'terra-icon/lib/icon/IconEllipses';
 import IconPerson from 'terra-icon/lib/icon/IconPerson';
 import ProfileLinks from './ProfileLinks';
@@ -31,10 +32,8 @@ const propTypes = {
    * The path to the login page.
    */
   signinUrl: PropTypes.string,
-  /**
-   * Determiniate of whether profile should render as signin link or profile button.
-   */
-  isSignIn: PropTypes.bool,
+  isExternal: PropTypes.bool,
+  target: PropTypes.string,
   /**
    * The content of the each profile items.
    */
@@ -50,26 +49,30 @@ const propTypes = {
 };
 
 const defaultProps = {
-  avatar: <IconPerson />,
   profileLinks: [],
-  isSignIn: false,
   id: 'terra-conumser-nav-profile-button',
 };
 
 const UserProfile = ({
-  userName, avatar, id, signoutUrl, signinUrl, isSignIn, profileLinks, handleClick, intl, ...customProps
+  userName, avatar, id, signoutUrl, signinUrl, isExternal, target, profileLinks, handleClick, intl, ...customProps
 }) => {
   let profileContent;
-  if (isSignIn) {
-    profileContent = (
-      <button className={cx('popup-button')} href={signinUrl}>
-        <Arrange
-          fitStart={<div className={cx('avatar')}>{avatar}</div>}
-          fill={<FormattedMessage id="Terra.Consumer.UserProfile.signin" />}
-          align="center"
-        />
-      </button>
-    );
+  const avatarIcon = <div className={cx('avatar')}>{avatar || <IconPerson />}</div>;
+
+  const setStaticProfile = (url, translationId) => (
+    <Button className={cx('popup-button')} href={url}>
+      <Arrange
+        fitStart={avatarIcon}
+        fill={<FormattedMessage id={translationId} />}
+        align="center"
+      />
+    </Button>
+  );
+
+  if (signinUrl && !(avatar || userName)) {
+    profileContent = setStaticProfile(signinUrl, 'Terra.Consumer.UserProfile.signin');
+  } else if (!(avatar || userName || signinUrl)) {
+    profileContent = setStaticProfile(signoutUrl, 'Terra.Consumer.UserProfile.signout');
   } else {
     const content = (
       <div>
@@ -85,7 +88,7 @@ const UserProfile = ({
     profileContent = (
       <button className={cx('popup-button')} onClick={() => handleClick({ title, content })}>
         <Arrange
-          fitStart={<div className={cx('avatar')}>{avatar}</div>}
+          fitStart={avatarIcon}
           fill={<span>{userName}</span>}
           fitEnd={<IconEllipses className={cx('icon')} id={id} />}
           align="center"

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -32,8 +32,6 @@ const propTypes = {
    * The path to the login page.
    */
   signinUrl: PropTypes.string,
-  isExternal: PropTypes.bool,
-  target: PropTypes.string,
   /**
    * The content of the each profile items.
    */
@@ -54,7 +52,7 @@ const defaultProps = {
 };
 
 const UserProfile = ({
-  userName, avatar, id, signoutUrl, signinUrl, isExternal, target, profileLinks, handleClick, intl, ...customProps
+  userName, avatar, id, signoutUrl, signinUrl, profileLinks, handleClick, intl, ...customProps
 }) => {
   let profileContent;
   const avatarIcon = <div className={cx('avatar')}>{avatar || <IconPerson />}</div>;

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Arrange from 'terra-arrange';
 import classNames from 'classnames/bind';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
-import Button from 'terra-button';
 import IconEllipses from 'terra-icon/lib/icon/IconEllipses';
 import IconPerson from 'terra-icon/lib/icon/IconPerson';
 import ProfileLinks from './ProfileLinks';
@@ -25,11 +24,11 @@ const propTypes = {
    */
   id: PropTypes.string,
   /**
-   * The path signout button would redirect to.
+   * The path signing out would redirect to. This link, when user data is available, will appear in the popup/modal, otherwise will display as the profile link itself.
    */
   signoutUrl: PropTypes.string.isRequired,
   /**
-   * The path to the login page.
+   * The path to the login page; this only gets displayed on the profile if no user information is provided along side this link
    */
   signinUrl: PropTypes.string,
   /**
@@ -57,27 +56,37 @@ const UserProfile = ({
   let profileContent;
   const avatarIcon = <div className={cx('avatar')}>{avatar || <IconPerson />}</div>;
 
-  const setStaticProfile = (url, translationId) => (
-    <Button className={cx('popup-button')} href={url}>
+  const singleProfileLink = (url, translationId) => (
+    <a href={url} className={cx('profile-text')}>
       <Arrange
+        className={cx('popup-button')}
         fitStart={avatarIcon}
         fill={<FormattedMessage id={translationId} />}
         align="center"
       />
-    </Button>
+    </a>
   );
 
-  if (signinUrl && !(avatar || userName)) {
-    profileContent = setStaticProfile(signinUrl, 'Terra.Consumer.UserProfile.signin');
-  } else if (!(avatar || userName || signinUrl)) {
-    profileContent = setStaticProfile(signoutUrl, 'Terra.Consumer.UserProfile.signout');
+  /*
+   * Logic tree:
+   *  If no user infomation is available, specifically the avatar and username, then one of two things will happen.
+   *   1: a signIn link was provided and therefore the sign IN option will be presented.
+   *   2: no signIn link was provided and as such the sign OUT link will be presented.
+   * Otherwise, the profile will display as normal with onclick opening the popup/modal depending on screensize,
+   *   desktop/modal respectively.
+   */
+  if (!(avatar || userName)) {
+    profileContent = signinUrl ?
+      singleProfileLink(signinUrl, 'Terra.Consumer.UserProfile.signin')
+    :
+      singleProfileLink(signoutUrl, 'Terra.Consumer.UserProfile.signout');
   } else {
     const content = (
       <div>
         <ProfileLinks linkItems={profileLinks} />
-        <button className={cx('link', 'signout-border')} href={signoutUrl}>
+        <a className={cx('link', 'signout-border')} href={signoutUrl}>
           <FormattedMessage id="Terra.Consumer.UserProfile.signout" />
-        </button>
+        </a>
       </div>
     );
 

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
@@ -98,6 +98,7 @@
     margin-top: 3px;
     padding: 20px 25px;
     text-align: left;
+    text-decoration: none;
     width: 100%;
 
     @media screen and (max-width: $terra-medium-breakpoint) {
@@ -110,6 +111,10 @@
       background: var(--terra-consumer-profile-hover-background, rgba(255, 255, 255, 0.4));
       color: var(--terra-consumer-profile-link-color, #3d3d3d);
     }
+  }
+
+  .profile-text {
+    text-decoration: none;
   }
 
   .avatar {

--- a/packages/terra-consumer-nav/tests/jest/components/UserProfile.test.jsx
+++ b/packages/terra-consumer-nav/tests/jest/components/UserProfile.test.jsx
@@ -18,10 +18,10 @@ const profileLinks = [
 
 describe('UserProfile', () => {
   // Snapshot Tests
-  it('should render a user profile with avatar,name and popup button', () => {
+  it('should render a user profile with avatar, name and popup button', () => {
     const wrapper = shallow(<UserProfile
       profileLinks={profileLinks}
-      name="Anthony Martial"
+      userName="Anthony Martial"
       avatar={<IconPerson />}
       signoutUrl="http://localhost:8080/"
     />);
@@ -29,12 +29,17 @@ describe('UserProfile', () => {
   });
 
   it('should render a default avatar when none is provided', () => {
-    const wrapper = shallow(<UserProfile name="Test user" profileLinks={profileLinks} />);
+    const wrapper = shallow(<UserProfile userName="Test user" profileLinks={profileLinks} />);
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should render as a signin link when specified', () => {
-    const wrapper = shallow(<UserProfile isSignIn signinUrl="google.com" />);
+  it('should render as a signin link when a signinUrl and no user data is provided', () => {
+    const wrapper = shallow(<UserProfile signinUrl="google.com" />);
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render as a signout link when no user data or signinUrl is provided', () => {
+    const wrapper = shallow(<UserProfile signoutUrl="google.com" />);
     expect(wrapper).toMatchSnapshot();
   });
 });

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/UserProfile.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/UserProfile.test.jsx.snap
@@ -2,7 +2,6 @@
 
 exports[`UserProfile should render a default avatar when none is provided 1`] = `
 <div
-  name="Test user"
   profileLinks={
     Array [
       Object {
@@ -23,10 +22,11 @@ exports[`UserProfile should render a default avatar when none is provided 1`] = 
       },
     ]
   }
+  userName="Test user"
 />
 `;
 
-exports[`UserProfile should render a user profile with avatar,name and popup button 1`] = `
+exports[`UserProfile should render a user profile with avatar, name and popup button 1`] = `
 <div
   avatar={
     <IconPerson
@@ -35,7 +35,6 @@ exports[`UserProfile should render a user profile with avatar,name and popup but
       xmlns="http://www.w3.org/2000/svg"
     />
   }
-  name="Anthony Martial"
   profileLinks={
     Array [
       Object {
@@ -57,12 +56,18 @@ exports[`UserProfile should render a user profile with avatar,name and popup but
     ]
   }
   signoutUrl="http://localhost:8080/"
+  userName="Anthony Martial"
 />
 `;
 
-exports[`UserProfile should render as a signin link when specified 1`] = `
+exports[`UserProfile should render as a signin link when a signinUrl and no user data is provided 1`] = `
 <div
-  isSignIn={true}
   signinUrl="google.com"
+/>
+`;
+
+exports[`UserProfile should render as a signout link when no user data or signinUrl is provided 1`] = `
+<div
+  signoutUrl="google.com"
 />
 `;

--- a/packages/terra-consumer-nav/tests/nightwatch/NavTestRoutes.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/NavTestRoutes.jsx
@@ -7,8 +7,9 @@ import NavTests from './NavTests';
 // Test Cases
 import BurgerButtonTest from './BurgerButtonTest';
 import HelpButtonTest from './HelpButtonTest';
-import SimpleNav from './SimpleNav';
 import NavLogoTest from './NavLogoTest';
+import ProfileButtonTest from './ProfileButtonTest';
+import SimpleNav from './SimpleNav';
 import SimpleNavWithTextLogo from './SimpleNavWithTextLogo';
 
 const routes = (
@@ -16,9 +17,10 @@ const routes = (
     <Route path="/tests/nav-tests" component={NavTests} />
     <Route path="/tests/nav-tests/burger-button" component={BurgerButtonTest} />
     <Route path="/tests/nav-tests/help-button" component={HelpButtonTest} />
+    <Route path="/tests/nav-tests/logo" component={NavLogoTest} />
+    <Route path="/tests/nav-tests/profile-button" component={ProfileButtonTest} />
     <Route path="/tests/nav-tests/simple-nav" component={SimpleNav} />
     <Route path="/tests/nav-tests/simple-nav-logo-text" component={SimpleNavWithTextLogo} />
-    <Route path="/tests/nav-tests/logo" component={NavLogoTest} />
   </div>
 );
 

--- a/packages/terra-consumer-nav/tests/nightwatch/NavTests.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/NavTests.jsx
@@ -7,9 +7,10 @@ const NavTests = () => (
     <ul>
       <li><a href="/#/tests/nav-tests/burger-button">Burger Button</a></li>
       <li><a href="/#/tests/nav-tests/help-button">Help Button</a></li>
+      <li><a href="/#/tests/nav-tests/logo">Nav Logo</a></li>
+      <li><a href="/#/tests/nav-tests/profile-button">Profile Button</a></li>
       <li><a href="/#/tests/nav-tests/simple-nav">Simple Nav</a></li>
       <li><a href="/#/tests/nav-tests/simple-nav-logo-text">Simple Nav with text logo</a></li>
-      <li><a href="/#/tests/nav-tests/logo">Nav Logo</a></li>
     </ul>
   </div>
 );

--- a/packages/terra-consumer-nav/tests/nightwatch/ProfileButtonTest.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/ProfileButtonTest.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import UserProfile from '../../src/components/user-profile/UserProfile';
+import I18nShell from './I18nShell';
+
+/* eslint-disable no-alert */
+const defaultProps = {
+  userName: 'Aegon Targaryen',
+  signoutUrl: 'http://www.google.com',
+  profileLinks: [],
+  handleClick: () => { alert('callback to open popup'); },
+};
+
+const signinProps = {
+  signinUrl: 'http://www.google.com',
+  signoutUrl: 'http://www.google.com',
+  handleClick: () => {},
+};
+
+const signoutProps = {
+  signoutUrl: 'http://www.google.com',
+  handleClick: () => {},
+};
+
+export default () => (
+  <I18nShell>
+    <div style={{ width: '320px' }}>
+      <p>A default user profile:</p>
+      <UserProfile {...defaultProps} />
+      <p>A sign in link when no user info is given, but a sign in link is:</p>
+      <UserProfile {...signinProps} />
+      <p>A sign out link when no user info or a sign in link is given:</p>
+      <UserProfile {...signoutProps} />
+    </div>
+  </I18nShell>
+);

--- a/packages/terra-consumer-nav/tests/nightwatch/SimpleNav.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/SimpleNav.jsx
@@ -125,6 +125,9 @@ const nav = {
     isCard: true,
   },
   profile: {
+    userName: 'John Snow',
+    signinUrl: 'http://localhost:8080/',
+    signoutUrl: 'http://localhost:8080/',
     profileLinks:
     [
       {
@@ -194,10 +197,6 @@ const nav = {
           },
         ],
       }],
-      // comment out userName to see signin
-    userName: 'John Snow',
-    signinUrl: 'http://localhost:8080/',
-    signoutUrl: 'http://localhost:8080/',
   },
 };
 


### PR DESCRIPTION
### Summary
Move logic for determining which link to render to profile component.
Add logic to render sign out as the main button when certain criteria are met.

Thanks for contributing to Terra. 
@cerner/terra
