### PR TITLE
removing brackets from language option

### DIFF
--- a/packages/terra-consumer-layout/tests/nightwatch/PortalLayout.jsx
+++ b/packages/terra-consumer-layout/tests/nightwatch/PortalLayout.jsx
@@ -278,7 +278,7 @@ const data = {
           target: '_self',
           url: '#',
           isExternal: true,
-          text: 'English (United States)',
+          text: 'English - United States',
           subItems: [
             {
               'data-locale': 'ar',
@@ -296,13 +296,13 @@ const data = {
               'data-locale': 'en-gb',
               isExternal: true,
               url: '#3',
-              text: 'English (United Kingdom)',
+              text: 'English - United Kingdom',
             },
             {
               'data-locale': 'fr-fr',
               isExternal: true,
               url: '#4',
-              text: 'Fran\u00e7ais (France)',
+              text: 'Fran\u00e7ais - France',
             },
           ],
         },

--- a/packages/terra-consumer-nav/tests/nightwatch/SimpleNav.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/SimpleNav.jsx
@@ -166,7 +166,7 @@ const nav = {
       {
         isExternal: true,
         url: '#',
-        text: 'English (United States)',
+        text: 'English - United States',
         subItems: [
           {
             'data-locale': 'ar',
@@ -184,13 +184,13 @@ const nav = {
             'data-locale': 'en-gb',
             isExternal: true,
             url: '#3',
-            text: 'English (United Kingdom)',
+            text: 'English - United Kingdom',
           },
           {
             'data-locale': 'fr-fr',
             isExternal: true,
             url: '#4',
-            text: 'Fran\u00e7ais (France)',
+            text: 'Fran\u00e7ais - France',
           },
         ],
       }],


### PR DESCRIPTION
removing brackets from language option for now as having issue in rendering language item with brakctes in rtl

One option we have to fix this by appending markup (RLM OR LRM) to values similar how [portal does](https://github.cerner.com/patient-portal/style-guide/blob/master/style_guide/utils/translations.py#L96)

 . Currently the data flow to component is dynamic and not sure if its recommended to check dir in react component  [profile link text](https://github.com/cerner/terra-consumer/blob/master/packages/terra-consumer-nav/src/components/user-profile/ProfileLinks.jsx#L59) to append unicode respectively. Believing it is not straight forward to append the markup I opted to remove the brackets for now.
![image](https://user-images.githubusercontent.com/6234682/30352755-799ae1ba-97e7-11e7-9499-c12211588cdc.png) 


