### PR TITLE
Fixed modal close button alignment and padding issue

### DIFF
--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,5 +1,12 @@
 ChangeLog
 =========
+#0.1.0 - (September 15, 2017)
+
+### Changed
+- Fix padding issues
+- Fix modal close button alignment issue.
+
+------------------
 
 # 0.1.0-BETA.6 - (September 15, 2017)
 

--- a/packages/terra-consumer-nav/src/components/modal/Modal.scss
+++ b/packages/terra-consumer-nav/src/components/modal/Modal.scss
@@ -53,9 +53,8 @@
   .close-button {
     color: var(--terra-consumer--modal-close-button-color, #fff) !important;
     font-size: 16px !important;
-    margin: 0;
-    padding: 0;
-
+    margin: 0 !important;
+    padding: 0 !important;
 
     &:hover {
       color: var(--terra-consumer--modal-close-button-hover-color, #777) !important;

--- a/packages/terra-consumer-nav/src/components/modal/Modal.scss
+++ b/packages/terra-consumer-nav/src/components/modal/Modal.scss
@@ -43,6 +43,7 @@
     padding: 0;
     position: absolute;
     right: 20px;
+    top: 0;
 
     @media screen and (max-width: $terra-tiny-breakpoint) {
       right: 15px;
@@ -52,6 +53,9 @@
   .close-button {
     color: var(--terra-consumer--modal-close-button-color, #fff) !important;
     font-size: 16px !important;
+    margin: 0;
+    padding: 0;
+
 
     &:hover {
       color: var(--terra-consumer--modal-close-button-hover-color, #777) !important;

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
@@ -66,6 +66,10 @@
     padding-right: 10px;
   }
 
+  .icon-text-padding:empty {
+    display: none;
+  }
+
   .toggler-padding {
     padding: 0 !important;
   }

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
@@ -62,8 +62,8 @@
     text-decoration: none;
   }
 
-  .item-text-padding {
-    padding-left: 10px;
+  .icon-text-padding {
+    padding-right: 10px;
   }
 
   .toggler-padding {

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -42,7 +42,7 @@ class NavHelpContent extends React.Component {
           <Arrange
             className={cx('help-item-text')}
             align="stretch"
-            fitStart={content.icon && <div className={cx('icon-text-padding')}>{content.icon}</div>}
+            fitStart={<div className={cx('icon-text-padding')}>{content.icon}</div>}
             fill={<div><SafeHtml text={content.text} /></div>}
             fitEnd={<div>{toggleIcon}</div>}
           />
@@ -68,7 +68,7 @@ class NavHelpContent extends React.Component {
             <Arrange
               className={cx('help-item-text')}
               align="center"
-              fitStart={!content.icon ? <div /> : <div className={cx('icon-text-padding')}>{content.icon}</div>}
+              fitStart={<div className={cx('icon-text-padding')}>{content.icon}</div>}
               fill={<div><SafeHtml text={content.text} /></div>}
             />
           </SmartLink>

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -31,7 +31,7 @@ class NavHelpContent extends React.Component {
     const contentList = customProps.helpContent.map((content, index) => {
       let contentElement;
       const isOpen = this.state.togglers[index];
-      const toggleIcon = isOpen ? <IconChevronUp className={cx('icon')} /> : <IconChevronDown className={cx('icon')} />;
+      const toggleIcon = isOpen ? <IconChevronUp /> : <IconChevronDown />;
 
       if (content.children && content.children.length > 0) {
         contentElement = (<Button
@@ -42,8 +42,8 @@ class NavHelpContent extends React.Component {
           <Arrange
             className={cx('help-item-text')}
             align="stretch"
-            fitStart={<div>{content.icon}</div>}
-            fill={<div className={cx('item-text-padding')}><SafeHtml text={content.text} /></div>}
+            fitStart={content.icon && <div className={cx('icon-text-padding')}>{content.icon}</div>}
+            fill={<div><SafeHtml text={content.text} /></div>}
             fitEnd={<div>{toggleIcon}</div>}
           />
           <Toggler isOpen={isOpen} isAnimated className={cx('toggler-padding')}>
@@ -68,8 +68,8 @@ class NavHelpContent extends React.Component {
             <Arrange
               className={cx('help-item-text')}
               align="center"
-              fitStart={<div className={cx('icon')}>{content.icon}</div>}
-              fill={<div className={cx('item-text-padding')}><SafeHtml text={content.text} /></div>}
+              fitStart={!content.icon ? <div /> : <div className={cx('icon-text-padding')}>{content.icon}</div>}
+              fill={<div><SafeHtml text={content.text} /></div>}
             />
           </SmartLink>
         );

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpPopup.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpPopup.scss
@@ -4,7 +4,7 @@
     color: var(--terra-consumer--popup-title-color, #fff);
     font-size: 20px;
     line-height: 30px;
-    padding: 5px 10px;
+    padding: 5px 15px;
     width: 100%;
   }
 

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
@@ -16,9 +16,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
       align="stretch"
       className="help-item-text"
       fill={
-        <div
-          className="item-text-padding"
-        >
+        <div>
           <SafeHtml
             text="Technical Questions"
           />
@@ -27,7 +25,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
       fitEnd={
         <div>
           <IconChevronDown
-            className="icon"
+            className=""
             data-name="Layer 1"
             isBidi={true}
             viewBox="0 0 48 48"
@@ -36,7 +34,9 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
         </div>
       }
       fitStart={
-        <div>
+        <div
+          className="icon-text-padding"
+        >
           <IconOutlineQuestionMark
             height={16}
             viewBox="0 0 48 48"
@@ -75,9 +75,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
       align="center"
       className="help-item-text"
       fill={
-        <div
-          className="item-text-padding"
-        >
+        <div>
           <SafeHtml
             text="Get Support ID"
           />
@@ -85,7 +83,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
       }
       fitStart={
         <div
-          className="icon"
+          className="icon-text-padding"
         >
           <IconOutlineQuestionMark
             height={16}


### PR DESCRIPTION
### Summary
- Fixed modal close button alignment issue.
- Changed padding to match UI callout.

Before:
![before](https://user-images.githubusercontent.com/21693381/30487116-77f22cfe-9a00-11e7-9ae2-fe9d4ba5f8b4.gif)


After:

![after](https://user-images.githubusercontent.com/21693381/30487159-9b3a9e76-9a00-11e7-8030-09cc48659817.gif)



Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
