### PR TITLE
get rid of all the css root variables

### DIFF
--- a/packages/terra-consumer-layout/CHANGELOG.md
+++ b/packages/terra-consumer-layout/CHANGELOG.md
@@ -6,6 +6,7 @@ ChangeLog
 ### Changed
 - Fixed nav height in IE
 - Fixed the help-button alignment issue.
+- Add fallbacks when removing root css variables
 
 ### Added
 - Theme-able padding for main container

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -1,31 +1,10 @@
 @import './variables';
 
-:root {
-  // Body
-  --terra-consumer-body-background-image: url('../background.jpg');
-  --terra-consumer-body-background-color: #c7d4ea;
-
-  // Nav
-  --terra-consumer-nav-background-color: rgba(255, 255, 255, 0.25);
-  --terra-consumer-nav-width: 320px;
-  --terra-consumer-nav-link-color: #3d3d3d;
-  --terra-consumer-nav-active-link-background: var(--terra-consumer-body-background-image);
-  --terra-consumer-nav-text-color: var(--terra-consumer-nav-link-color);
-  --terra-consumer-mobile-close-button-color: var(--terra-consumer-nav-link-color);
-
-  // profile
-  --terra-consumer-profile-link-border-background: var(--terra-consumer-body-background-image);
-  --terra-consumer-profile-link-background: var(--terra-consumer-nav-background-color);
-  --terra-consumer-profile-link-width: var(--terra-consumer-nav-width);
-  --terra-consumer-profile-link-color: var(--terra-consumer-nav-link-color);
-}
-
-
 :local {
   .wrap {
     background-attachment: fixed;
-    background-color: var(--terra-consumer-body-background-color);
-    background-image: var(--terra-consumer-body-background-image);
+    background-color: var(--terra-consumer-body-background-color, #c7d4ea);
+    background-image: var(--terra-consumer-body-background-image, url('http://d320j1w59ws5w0.cloudfront.net/terra-consumer-background-images.jpg'));
     background-size: cover;
     overflow-x: hidden;
 
@@ -46,16 +25,16 @@
 
   .nav {
     min-height: 100vh;
-    min-width: var(--terra-consumer-nav-width);
+    min-width: var(--terra-consumer-nav-width, 320px);
     position: relative;
-    width: var(--terra-consumer-nav-width);
+    width: var(--terra-consumer-nav-width, 320px);
     z-index: 100;
 
     @media screen and (max-width: $terra-medium-breakpoint) {
-      background-color: var(--terra-consumer-body-background-color);
+      background-color: var(--terra-consumer-body-background-color, #c7d4ea);
       box-shadow: 0 1px 3px rgba(28, 31, 33, 0.35);
       float: left;
-      margin-left: calc(var(--terra-consumer-nav-width) * -1);
+      margin-left: calc(var(--terra-consumer-nav-width, 320px) * -1);
       transform: translate3d(0, 0, 0);
       transition: transform 0.35s ease;
       will-change: transform;
@@ -68,7 +47,7 @@
     }
 
     &::before {
-      background-color: var(--terra-consumer-nav-background-color);
+      background-color: var(--terra-consumer-nav-background-color, rgba(255, 255, 255, 0.25));
       bottom: 0;
       content: '';
       left: 0;
@@ -81,7 +60,7 @@
 
   .open nav {
     @media screen and (max-width: $terra-medium-breakpoint) {
-      transform: translate3d(var(--terra-consumer-nav-width), 0, 0);
+      transform: translate3d(var(--terra-consumer-nav-width, 320px), 0, 0);
       transition-duration: 0.5s;
     }
 

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -5,6 +5,7 @@ ChangeLog
 ### Changed
 - Fix padding issues
 - Fix modal close button alignment issue.
+- Add fallbacks when removing root css variables
 
 ------------------
 

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -46,7 +46,7 @@
   }
 
   .close-button {
-    color: var(--terra-consumer-mobile-close-button-color, #fff) !important;
+    color: var(--terra-consumer-mobile-close-button-color, #3d3d3d) !important;
     font-size: 16px !important;
     line-height: 16px !important;
   }

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -3,7 +3,7 @@
 
 :local {
   .nav {
-    color: var(--terra-consumer-nav-text-color);
+    color: var(--terra-consumer-nav-text-color, #3d3d3d);
     /* nav is relative positioned and its height depends on the height of the main content next to it.
      * height: 100% makes sure nav height >= content height
     */
@@ -25,7 +25,7 @@
   .profile {
     bottom: 0;
     position: fixed;
-    width: var(--terra-consumer-profile-link-width);
+    width: var(--terra-consumer-profile-link-width, 320px);
 
     @media screen and (max-width: $terra-medium-breakpoint) {
       position: static;

--- a/packages/terra-consumer-nav/src/components/nav-burger-button/NavBurgerButton.scss
+++ b/packages/terra-consumer-nav/src/components/nav-burger-button/NavBurgerButton.scss
@@ -2,7 +2,7 @@
 
 :local {
   .burger {
-    color: var(--terra-consumer-burger-color, #fff) !important;
+    color: var(--terra-consumer-burger-color, #3d3d3d) !important;
     font-size: 20px !important;
 
     &:hover,

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
@@ -2,7 +2,7 @@
 
 :local {
   .item {
-    color: var(--terra-consumer-nav-link-color, #fff);
+    color: var(--terra-consumer-nav-link-color, #3d3d3d);
     display: flex;
     font-size: var(--terra-consumer-nav-link-font-size, 16px);
     line-height: 20px;
@@ -41,7 +41,7 @@
 
   .badge {
     align-self: center;
-    background: var(--terra-consumer-badge-background, #fff);
+    background: var(--terra-consumer-badge-background, #3d3d3d);
     border-radius: 10px;
     color: var(--terra-consumer-badge-color, #3d3d3d);
     display: inline-block;

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
@@ -22,7 +22,7 @@
 
     &:hover {
       background: var(--terra-consumer-link-hover-background, rgba(255, 255, 255, 0.4));
-      color: var(--terra-consumer-nav-link-color);
+      color: var(--terra-consumer-nav-link-color, #3d3d3d);
     }
   }
 

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
@@ -41,7 +41,7 @@
 
   .badge {
     align-self: center;
-    background: var(--terra-consumer-badge-background, #3d3d3d);
+    background: var(--terra-consumer-badge-background, #fff);
     border-radius: 10px;
     color: var(--terra-consumer-badge-color, #3d3d3d);
     display: inline-block;

--- a/packages/terra-consumer-nav/src/components/nav-toggler/NavToggler.scss
+++ b/packages/terra-consumer-nav/src/components/nav-toggler/NavToggler.scss
@@ -17,7 +17,7 @@
 
     &:hover {
       background: var(--terra-consumer-toggler-hover-background, rgba(255, 255, 255, 0.4));
-      color: var(--terra-consumer-nav-link-color);
+      color: var(--terra-consumer-nav-link-color, #3d3d3d);
     }
   }
 

--- a/packages/terra-consumer-nav/src/components/nav-toggler/NavToggler.scss
+++ b/packages/terra-consumer-nav/src/components/nav-toggler/NavToggler.scss
@@ -4,7 +4,7 @@
   .toggle-header {
     background-color: transparent;
     border: 0;
-    color: var(--terra-consumer-nav-link-color, #fff);
+    color: var(--terra-consumer-nav-link-color, #3d3d3d);
     cursor: pointer;
     display: block;
     font-size: inherit;

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
@@ -2,7 +2,7 @@
 
 :local {
   .profile {
-    background: var(--terra-consumer-profile-link-border-background);
+    background: var(--terra-consumer-profile-link-border-background, url('http://d320j1w59ws5w0.cloudfront.net/terra-consumer-background-images.jpg'));
     background-attachment: fixed;
     background-size: cover;
 
@@ -10,7 +10,7 @@
       background: none;
       background-attachment: none;
       background-size: none;
-      border-top: 3px solid var(--terra-consumer-body-background-color);
+      border-top: 3px solid var(--terra-consumer-body-background-color, #c7d4ea);
       margin-top: 5px;
     }
 


### PR DESCRIPTION
### Summary
variables declared in the root of our css cause issues in the consuming application. if they are present in the app bundle, and the app provides its root, and they end up in the same bundle, we are at the mercy of webpack to put the app's root below this repo's root.

Instead of relying on this, we should not use root in our module's css

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
