### PR TITLE
Prevent nav to scroll when modal is open

### DIFF
--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,17 +1,15 @@
 ChangeLog
 =========
-#0.1.1 - (September 18, 2017)
+#0.1.0 - (September 19, 2017)
 
 ### Changed
-- Fix padding issues.
-- Fix modal close button alignment issue.
-- Add fallbacks when removing root css variables
-- Fix profile icon and ellipses alignment.
-------------------
-
-# 0.1.0 - (September 15, 2017)
-- Change profile link image
-- Add theme variable for profile pop up link's hover color
+- Prevent the Nav scrolling when modal is open.
+- Fixed padding issues.
+- Fixed modal close button alignment issue.
+- Added fallbacks when removing root css variables.
+- Fixed profile icon and ellipses alignment.
+- Changed profile link image.
+- Added theme variable for profile pop up link's hover color.
 
 # 0.1.0-BETA.6 - (September 15, 2017)
 

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -19,6 +19,7 @@
   .modal-open {
     @media screen and (max-width: $terra-medium-breakpoint) {
       height: 100vh;
+      overflow: hidden;
     }
   }
 


### PR DESCRIPTION
### Summary
At present Nav height is set to 100vh when Settings modal is open. It causes the Nav scrollable when Modal is open. Made changes to prevented from scrolling when Modal is open.

Before:
![nav_before](https://user-images.githubusercontent.com/21693381/30564960-ae984248-9c94-11e7-88de-337b68402554.gif)

After:
![nav_after](https://user-images.githubusercontent.com/21693381/30565023-da5051e6-9c94-11e7-87d4-59607ea6e2a9.gif)





Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
