### PR TITLE
fix react router with full domain name links

### DIFF
--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -4,6 +4,9 @@ ChangeLog
 ### Changed
 # 0.1.0 - (September 19, 2017)
 
+### Added
+- For react router internal links, strip the domain/host off the url before providing it to the link to prevent linking to something like http://localhost:8080/http:localhost:8080/my-page
+
 ### Changed
 - Initial Stable Release
 - Prevent the Nav scrolling when modal is open.
@@ -14,6 +17,7 @@ ChangeLog
 - Changed profile link image.
 - Added theme variable for profile pop up link's hover color.
 - Allow the bar above the profile in mobile to be configured independently of the background color
+
 
 # 0.1.0-BETA.6 - (September 15, 2017)
 

--- a/packages/terra-consumer-nav/src/components/smart-link/SmartLink.jsx
+++ b/packages/terra-consumer-nav/src/components/smart-link/SmartLink.jsx
@@ -25,19 +25,30 @@ const SmartLink = ({
   handleClick,
   children,
   ...customProps
-}) => (
-  (isExternal || target === '_blank') ?
-    <a {...customProps} onClick={handleClick} target={target} href={url}>{children}</a> :
+}) => {
+  if (isExternal || target === '_blank') {
+    return (
+      <a {...customProps} onClick={handleClick} target={target} href={url}>{children}</a>
+    );
+  }
+  const a = document.createElement('a');
+  a.href = url;
+    // fix for pathname quirk in IE : http://stackoverflow.com/questions/956233/javascript-pathname-ie-quirk
+  const linkPath = a.pathname[0] === '/' ? a.pathname : `/${a.pathname}`;
+
+  return (
     <NavLink
       {...customProps}
       exact
       activeClassName={activeClass}
-      to={url}
+      to={linkPath}
       onClick={handleClick}
     >
       {children}
     </NavLink>
   );
+};
+
 
 SmartLink.propTypes = propTypes;
 SmartLink.defaultProps = defaultProps;


### PR DESCRIPTION
### Summary
For react router internal links, strip the domain/host off the url before providing it to the link to prevent linking to something like http://localhost:8080/http:localhost:8080/my-page

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
