### PR TITLE
adding fix for profile links close

### DIFF
--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -31,7 +31,7 @@
     width: var(--terra-consumer-nav-width, 320px);
     z-index: 200;
 
-    @media screen and (max-width: ($terra-medium-breakpoint - 1)) {
+    @media screen and (max-width: $terra-medium-breakpoint) {
       background-color: var(--terra-consumer-body-background-color, #c7d4ea);
       box-shadow: 0 1px 3px rgba(28, 31, 33, 0.35);
       float: left;
@@ -41,7 +41,7 @@
       will-change: transform;
     }
 
-    @media screen and (max-width: ($terra-tiny-breakpoint - 1)) {
+    @media screen and (max-width: $terra-tiny-breakpoint) {
       margin-left: -100%;
       min-width: 0;
       width: 100%;

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -31,7 +31,7 @@
     width: var(--terra-consumer-nav-width, 320px);
     z-index: 200;
 
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: ($terra-medium-breakpoint - 1)) {
       background-color: var(--terra-consumer-body-background-color, #c7d4ea);
       box-shadow: 0 1px 3px rgba(28, 31, 33, 0.35);
       float: left;
@@ -41,7 +41,7 @@
       will-change: transform;
     }
 
-    @media screen and (max-width: $terra-tiny-breakpoint) {
+    @media screen and (max-width: ($terra-tiny-breakpoint - 1)) {
       margin-left: -100%;
       min-width: 0;
       width: 100%;

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,5 +1,10 @@
 ChangeLog
 =========
+# 0.2.4 - (October 04, 2017)
+- Fixed it so when in mobile, clicking on the profile and help button links closes the modal and the nav panel
+
+------------------
+
 # 0.2.3 - (September 29, 2017)
 
 ### Changed

--- a/packages/terra-consumer-nav/src/Nav.jsx
+++ b/packages/terra-consumer-nav/src/Nav.jsx
@@ -70,10 +70,16 @@ class Nav extends React.Component {
 
     this.toggleModal = this.toggleModal.bind(this);
     this.handleOpenProfile = this.handleOpenProfile.bind(this);
+    this.handleProfileLinkClick = this.handleProfileLinkClick.bind(this);
   }
 
   handleOpenProfile(modalContent, numberOfLinks) {
     this.toggleModal(modalContent, numberOfLinks);
+  }
+
+  handleProfileLinkClick() {
+    this.toggleModal();
+    this.props.onRequestClose();
   }
 
   toggleModal(modalObject, numberOfLinks) {
@@ -105,7 +111,6 @@ class Nav extends React.Component {
       </Modal>
     );
 
-    console.log(this.state.numberOfLinks);
     // Imported directly from the terra-popup package, but this is an example of what its like
     // const PopupHeights = { 40: 40, 80: 80, 120: 120, 160: 160, 240: 240, 320: 320, 400: 400, 480: 480, 560: 560, 640: 640, 720: 720, 800: 800, 880: 880 };
     const popup = (
@@ -143,6 +148,7 @@ class Nav extends React.Component {
               {...profile}
               id={profileId}
               handleClick={this.handleOpenProfile}
+              onChildLinkClick={this.handleProfileLinkClick}
               isSignIn={profile.signinUrl && !(profile.avatar || profile.userName)}
             />
           </div>

--- a/packages/terra-consumer-nav/src/Nav.jsx
+++ b/packages/terra-consumer-nav/src/Nav.jsx
@@ -78,7 +78,11 @@ class Nav extends React.Component {
   }
 
   handleProfileLinkClick() {
-    this.toggleModal();
+    // close our modal so they can see the new page
+    this.setState({
+      isModalOpen: false,
+    });
+    // Close the navigation panel as well
     this.props.onRequestClose();
   }
 
@@ -148,7 +152,7 @@ class Nav extends React.Component {
               {...profile}
               id={profileId}
               handleClick={this.handleOpenProfile}
-              onChildLinkClick={this.handleProfileLinkClick}
+              onLinkClick={this.handleProfileLinkClick}
               isSignIn={profile.signinUrl && !(profile.avatar || profile.userName)}
             />
           </div>

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.jsx
@@ -77,7 +77,7 @@ class NavHelp extends React.Component {
       </button>
     );
 
-    const popupContent = <NavHelpContent helpContent={helpNavs} />;
+    const popupContent = <NavHelpContent helpContent={helpNavs} onLinkClick={this.togglePopup} />;
 
     const defaultElement = (
       <Modal

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Arrange from 'terra-arrange';
 import Button from 'terra-button';
 import classNames from 'classnames/bind';
@@ -10,6 +11,17 @@ import SmartLink from '../smart-link/SmartLink';
 import styles from './NavHelp.scss';
 
 const cx = classNames.bind(styles);
+
+const propTypes = {
+  helpContent: PropTypes.arrayOf(PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    children: PropTypes.array,
+    url: PropTypes.string,
+    isExternal: PropTypes.bool,
+    target: PropTypes.string,
+  })).isRequired,
+  onLinkClick: PropTypes.func.isRequired,
+};
 
 class NavHelpContent extends React.Component {
   constructor() {
@@ -26,9 +38,9 @@ class NavHelpContent extends React.Component {
   }
 
   render() {
-    const { ...customProps } = this.props;
+    const { helpContent, onLinkClick } = this.props;
 
-    const contentList = customProps.helpContent.map((content, index) => {
+    const contentList = helpContent.map((content, index) => {
       let contentElement;
       const isOpen = this.state.togglers[index];
       const toggleIcon = isOpen ? <IconChevronUp /> : <IconChevronDown />;
@@ -64,6 +76,7 @@ class NavHelpContent extends React.Component {
             url={content.url}
             target={content.target}
             isExternal={content.isExternal}
+            handleClick={onLinkClick}
           >
             <Arrange
               className={cx('help-item-text')}
@@ -84,5 +97,7 @@ class NavHelpContent extends React.Component {
     );
   }
 }
+
+NavHelpContent.propTypes = propTypes;
 
 export default NavHelpContent;

--- a/packages/terra-consumer-nav/src/components/user-profile/ProfileLink.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/ProfileLink.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames/bind';
+import PropTypes from 'prop-types';
 import SafeHtml from '../safe-html/SafeHtml';
 import navElementShape from '../../NavPropShapes';
 import SmartLink from '../smart-link/SmartLink';
@@ -7,13 +8,20 @@ import styles from './UserProfile.scss';
 
 const cx = classNames.bind(styles);
 
-const propTypes = { ...navElementShape };
+const propTypes = {
+  /**
+  * An optional function. When supplied, gets triggered on link click.
+  */
+  handleClick: PropTypes.func,
+  ...navElementShape,
+};
 
 const ProfileLink = ({
   text,
   url,
   target,
   isExternal,
+  handleClick,
   ...customProps
 }) => (
   <SmartLink
@@ -22,6 +30,7 @@ const ProfileLink = ({
     target={target}
     isExternal={isExternal}
     className={cx('link', 'profile-item-border', customProps.className)}
+    handleClick={handleClick}
   >
     <SafeHtml text={text} />
   </SmartLink>

--- a/packages/terra-consumer-nav/src/components/user-profile/ProfileLinks.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/ProfileLinks.jsx
@@ -24,6 +24,10 @@ const propTypes = {
       },
     ),
   ),
+  /**
+   * An optional function. When supplied, gets triggered on link click.
+   */
+  handleClick: PropTypes.func,
 };
 
 const defaultProps = {
@@ -61,7 +65,7 @@ class ProfileLinks extends React.Component {
               />
             </button>
             <Toggler isOpen={isOpen} isAnimated className={cx('toggler')}>
-              {linkItem.subItems.map(subItem => (<ProfileLink key={subItem.text} {...subItem} />))}
+              {linkItem.subItems.map(subItem => (<ProfileLink key={subItem.text} {...subItem} handleClick={this.props.handleClick} />))}
             </Toggler>
           </div>
         );
@@ -73,6 +77,7 @@ class ProfileLinks extends React.Component {
           text={linkItem.text}
           target={linkItem.target}
           isExternal={linkItem.isExternal}
+          handleClick={this.props.handleClick}
         />);
     });
 

--- a/packages/terra-consumer-nav/src/components/user-profile/ProfileLinks.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/ProfileLinks.jsx
@@ -49,7 +49,7 @@ class ProfileLinks extends React.Component {
   }
 
   render() {
-    const { linkItems, ...customProps } = this.props;
+    const { linkItems, handleClick, ...customProps } = this.props;
 
     const profileLinks = linkItems.map((linkItem, index) => {
       if (linkItem.subItems && linkItem.subItems.length > 0) {
@@ -65,7 +65,7 @@ class ProfileLinks extends React.Component {
               />
             </button>
             <Toggler isOpen={isOpen} isAnimated className={cx('toggler')}>
-              {linkItem.subItems.map(subItem => (<ProfileLink key={subItem.text} {...subItem} handleClick={this.props.handleClick} />))}
+              {linkItem.subItems.map(subItem => (<ProfileLink key={subItem.text} {...subItem} handleClick={handleClick} />))}
             </Toggler>
           </div>
         );
@@ -77,7 +77,7 @@ class ProfileLinks extends React.Component {
           text={linkItem.text}
           target={linkItem.target}
           isExternal={linkItem.isExternal}
-          handleClick={this.props.handleClick}
+          handleClick={handleClick}
         />);
     });
 

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -48,6 +48,11 @@ const propTypes = {
    * Injected react-intl formatting api
    */
   intl: intlShape.isRequired,
+  /**
+   * A function used as a callback when user clicks on any link.
+   */
+  onChildLinkClick: PropTypes.func.isRequired,
+
 };
 
 const defaultProps = {
@@ -58,7 +63,7 @@ const defaultProps = {
 };
 
 const UserProfile = ({
-  userName, avatar, id, signoutUrl, signinUrl, isSignIn, profileLinks, handleClick, intl, ...customProps
+  userName, avatar, id, signoutUrl, signinUrl, isSignIn, profileLinks, handleClick, onChildLinkClick, intl, ...customProps
 }) => {
   let profileContent;
   if (isSignIn) {
@@ -74,7 +79,7 @@ const UserProfile = ({
   } else {
     const content = (
       <div>
-        <ProfileLinks linkItems={profileLinks} />
+        <ProfileLinks linkItems={profileLinks} handleClick={onChildLinkClick} />
         <a className={cx('link', 'signout-border')} href={signoutUrl}>
           <FormattedMessage id="Terra.Consumer.UserProfile.signout" />
         </a>

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.jsx
@@ -49,9 +49,9 @@ const propTypes = {
    */
   intl: intlShape.isRequired,
   /**
-   * A function used as a callback when user clicks on any link.
+   * A function used as a callback when user clicks on any link in the content.
    */
-  onChildLinkClick: PropTypes.func.isRequired,
+  onLinkClick: PropTypes.func.isRequired,
 
 };
 
@@ -63,7 +63,7 @@ const defaultProps = {
 };
 
 const UserProfile = ({
-  userName, avatar, id, signoutUrl, signinUrl, isSignIn, profileLinks, handleClick, onChildLinkClick, intl, ...customProps
+  userName, avatar, id, signoutUrl, signinUrl, isSignIn, profileLinks, handleClick, onLinkClick, intl, ...customProps
 }) => {
   let profileContent;
   if (isSignIn) {
@@ -79,7 +79,7 @@ const UserProfile = ({
   } else {
     const content = (
       <div>
-        <ProfileLinks linkItems={profileLinks} handleClick={onChildLinkClick} />
+        <ProfileLinks linkItems={profileLinks} handleClick={onLinkClick} />
         <a className={cx('link', 'signout-border')} href={signoutUrl}>
           <FormattedMessage id="Terra.Consumer.UserProfile.signout" />
         </a>

--- a/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
@@ -80,6 +80,7 @@ exports[`Nav should render a default component 1`] = `
     <InjectIntl(UserProfile)
       handleClick={[Function]}
       id="profile-popup-button"
+      onLinkClick={[Function]}
       profileId="profile-popup-button"
       profileLinks={
         Array [

--- a/packages/terra-consumer-nav/tests/jest/components/NavHelpContent.test.jsx
+++ b/packages/terra-consumer-nav/tests/jest/components/NavHelpContent.test.jsx
@@ -23,7 +23,7 @@ const testData = [
 describe('Content of the Help Modal/Popup', () => {
   // Snapshot Tests
   it('should render a list of items with/without toggler', () => {
-    const wrapper = shallow(<NavHelpContent helpContent={testData} />);
+    const wrapper = shallow(<NavHelpContent helpContent={testData} onLinkClick={jest.fn()} />);
     expect(wrapper).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
### Summary
clicking on a link inside a modal wasn't triggering a close of the modal. This wasnt discovered with portal since it refreshes the page, but with dex using react router, it would navigate the user behind the modal but not show them. Now any clicks close the modal and nav panel

[CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
