### PR TITLE
badge accepts strings

### DIFF
--- a/packages/terra-consumer-layout/tests/nightwatch/PortalLayout.jsx
+++ b/packages/terra-consumer-layout/tests/nightwatch/PortalLayout.jsx
@@ -22,20 +22,20 @@ const data = {
       },
       {
         text: 'Messaging',
-        badgeValue: 2,
+        badgeValue: '!',
         icon: <IconPerson />,
         subItems: [
           {
             isExternal: true,
             url: '#inbox',
             text: 'Inbox',
-            badgeValue: 1,
+            badgeValue: "'",
           },
           {
             isExternal: true,
             url: '#sent',
             text: 'Sent',
-            badgeValue: 1,
+            badgeValue: '   ',
           },
           {
             isExternal: true,

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,6 +1,15 @@
 ChangeLog
 
+# 0.2.5 - (October 05, 2017)
+
+### Added
+- Strings can now be passed as badge values.
+
+------------------
+
 # 0.2.4 - (October 04, 2017)
+
+### Changed
 - Fixed it so when in mobile, clicking on the profile and help button links closes the modal and the nav panel
 - Fix user profile border top
 

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -5,6 +5,9 @@ ChangeLog
 ### Added
 - Strings can now be passed as badge values.
 
+### Changed
+- Users can now pass a '0' as a badge value.
+
 ------------------
 
 # 0.2.4 - (October 04, 2017)

--- a/packages/terra-consumer-nav/src/NavPropShapes.js
+++ b/packages/terra-consumer-nav/src/NavPropShapes.js
@@ -28,7 +28,10 @@ export const navItemShape = {
   /**
    * An optional badge. When supplied, displays the value inline, styled alongside the text.
    */
-  badgeValue: PropTypes.number,
+  badgeValue: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
 };
 
 export const navItemShapeDefaults = {

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
@@ -54,13 +54,16 @@ const NavItem = ({
   ...customProps
 }) => {
   const activeClass = cx('active');
+  const badgeString = `${badgeValue}`;
 
-  const itemLabel = (<div>
-    <SafeHtml text={text} />
-    { badgeValue > 0 &&
-      <div className={cx('badge')}>{badgeValue}</div>
-    }
-  </div>);
+  const itemLabel = (
+    <div>
+      <SafeHtml text={text} />
+      { (!!badgeValue && badgeString.trim()) &&
+        <SafeHtml className={cx('badge')} text={badgeString} />
+      }
+    </div>
+  );
 
   const itemText = (
     <div className={cx('item')}>
@@ -68,6 +71,7 @@ const NavItem = ({
       <div className={cx('label')}>{itemLabel}</div>
     </div>
   );
+
   return (children && children.length > 0) ?
     (<NavToggler
       {...customProps}

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.jsx
@@ -59,7 +59,7 @@ const NavItem = ({
   const itemLabel = (
     <div>
       <SafeHtml text={text} />
-      { (!!badgeValue && badgeString.trim()) &&
+      { (badgeValue !== undefined && badgeValue !== null) && badgeString.trim() &&
         <SafeHtml className={cx('badge')} text={badgeString} />
       }
     </div>

--- a/packages/terra-consumer-nav/tests/jest/components/NavItem.test.jsx
+++ b/packages/terra-consumer-nav/tests/jest/components/NavItem.test.jsx
@@ -5,7 +5,6 @@ const testData = {
   url: '#testPath',
   text: 'testIcon',
   isActive: false,
-  badgeValue: 0,
 };
 
 const toggleData = {
@@ -25,6 +24,18 @@ describe('Nav Item', () => {
   it('should apply custom classes', () => {
     const wrapper = shallow(<NavItem {...testData} className="test-class" />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  describe('badge', () => {
+    it('should render when a number > 0 is provided', () => {
+      const wrapper = shallow(<NavItem {...testData} badgeValue={1} />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render when a string is provided', () => {
+      const wrapper = shallow(<NavItem {...testData} badgeValue={'!'} />);
+      expect(wrapper).toMatchSnapshot();
+    });
   });
 });
 

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavItem.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavItem.test.jsx.snap
@@ -29,6 +29,72 @@ exports[`Nav Item as Toggler should render a nav as a toggle component 1`] = `
 </div>
 `;
 
+exports[`Nav Item badge should render when a number > 0 is provided 1`] = `
+<div
+  className=""
+>
+  <SmartLink
+    activeClass="active"
+    className="link"
+    handleClick={[Function]}
+    isExternal={false}
+    target="_self"
+    url="#testPath"
+  >
+    <div
+      className="item"
+    >
+      <div
+        className="label"
+      >
+        <div>
+          <SafeHtml
+            text="testIcon"
+          />
+          <SafeHtml
+            className="badge"
+            text="1"
+          />
+        </div>
+      </div>
+    </div>
+  </SmartLink>
+</div>
+`;
+
+exports[`Nav Item badge should render when a string is provided 1`] = `
+<div
+  className=""
+>
+  <SmartLink
+    activeClass="active"
+    className="link"
+    handleClick={[Function]}
+    isExternal={false}
+    target="_self"
+    url="#testPath"
+  >
+    <div
+      className="item"
+    >
+      <div
+        className="label"
+      >
+        <div>
+          <SafeHtml
+            text="testIcon"
+          />
+          <SafeHtml
+            className="badge"
+            text="!"
+          />
+        </div>
+      </div>
+    </div>
+  </SmartLink>
+</div>
+`;
+
 exports[`Nav Item should apply custom classes 1`] = `
 <div
   className=""

--- a/packages/terra-consumer-nav/tests/nightwatch/SimpleNav.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/SimpleNav.jsx
@@ -19,26 +19,26 @@ const nav = {
     },
     {
       text: 'Messaging',
-      badgeValue: 2,
+      badgeValue: '!', // basic string symbol test
       icon: <IconPerson />,
       subItems: [
         {
           isExternal: true,
           url: '#inbox',
           text: 'Inbox',
-          badgeValue: 1,
+          badgeValue: "'", // SafeHtml test
         },
         {
           isExternal: true,
           url: '#sent',
           text: 'Sent',
-          badgeValue: 1,
+          badgeValue: '  ', // space test, should not render badge
         },
         {
           isExternal: true,
           url: '#inbox',
           text: 'Inbox',
-          badgeValue: 1,
+          badgeValue: 1, // number test
         },
         {
           isExternal: true,


### PR DESCRIPTION
### Summary
Change to badges to allow passing of strings into the badge, instead of just numbers. This allows for users to customize what displays such as (  !  ) or (  1  ).

### Additional Details
Putting text through SafeHtml so users can put translated text or symbols as they desire into the badge.
Empty strings should not be rendered as a badge. taken care of by use of .trim() and truthy check.

@mhemesath @alex-bezek @zhongyn 