### PR TITLE
early mobile view fix 

### DIFF
--- a/packages/terra-consumer-layout/CHANGELOG.md
+++ b/packages/terra-consumer-layout/CHANGELOG.md
@@ -3,6 +3,7 @@ ChangeLog
 
 ### Changed
 - Updating layout example to include badge
+- Early mobile view fix
 
 # 0.1.5 - (October 04, 2017)
 

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -8,8 +8,7 @@
     background-size: cover;
     overflow-x: hidden;
 
-    @media screen and (max-width: $terra-medium-breakpoint),
-      screen and (orientation: landscape) and (max-width: $terra-large-breakpoint) {
+    @supports (-webkit-overflow-scrolling: touch) {
       background-image: none;
     }
   }

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -8,6 +8,7 @@ ChangeLog
 ### Changed
 - Users can now pass a '0' as a badge value.
 - Fix the sub item badge alignment
+- Early mobile view fix
 
 ------------------
 

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -24,8 +24,7 @@
     position: fixed;
     width: var(--terra-consumer-profile-link-width, 320px);
 
-    @media screen and (max-width: $terra-medium-breakpoint),
-      screen and (orientation: landscape) and (max-width: $terra-large-breakpoint) {
+    @supports (-webkit-overflow-scrolling: touch) {
       position: static;
     }
   }

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
@@ -8,13 +8,11 @@
     border-top: var(--terra-consumer-profile-link-border-top, 3px solid #c7d3ea);
     margin-top: 5px;
 
-    @media screen and (max-width: $terra-medium-breakpoint),
-      screen and (orientation: landscape) and (max-width: $terra-large-breakpoint) {
+    @supports (-webkit-overflow-scrolling: touch) {
       background: none;
       background-attachment: none;
       background-size: none;
     }
-
     @media screen and (max-width: $terra-tiny-breakpoint) {
       width: 100vw;
     }
@@ -102,8 +100,7 @@
     text-align: left;
     width: 100%;
 
-    @media screen and (max-width: $terra-medium-breakpoint),
-      screen and (orientation: landscape) and (max-width: $terra-large-breakpoint) {
+    @supports (-webkit-overflow-scrolling: touch) {
       background: inherit;
       margin-top: 0;
     }


### PR DESCRIPTION
cause - using large breakpoint

fix - using  @supports (-webkit-overflow-scrolling: touch)

One can only test in actual devices or simulator. 