### PR TITLE
Align breakpoints with terra-core

### DIFF
--- a/packages/terra-consumer-layout/CHANGELOG.md
+++ b/packages/terra-consumer-layout/CHANGELOG.md
@@ -3,6 +3,7 @@ ChangeLog
 
 ### Changed
 - Fixed punch through effect
+- Align media query with terra-core
 
 # 0.1.6 - (October 06, 2017)
 

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -30,7 +30,7 @@
     width: var(--terra-consumer-nav-width, 320px);
     z-index: 200;
 
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       background-color: var(--terra-consumer-body-background-color, #c7d4ea);
       box-shadow: 0 1px 3px rgba(28, 31, 33, 0.35);
       float: left;
@@ -40,7 +40,7 @@
       will-change: transform;
     }
 
-    @media screen and (max-width: $terra-tiny-breakpoint) {
+    @media screen and (max-width: $terra-tiny-breakpoint - 1) {
       margin-left: -100%;
       min-width: 0;
       width: 100%;
@@ -59,12 +59,12 @@
   }
 
   .open nav {
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       transform: translate3d(var(--terra-consumer-nav-width, 320px), 0, 0);
       transition-duration: 0.5s;
     }
 
-    @media screen and (max-width: $terra-tiny-breakpoint) {
+    @media screen and (max-width: $terra-tiny-breakpoint - 1) {
       transform: translate3d(100%, 0, 0);
     }
   }
@@ -82,7 +82,7 @@
 
 
   .open .main-container {
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       overflow: hidden;
       position: fixed;
       width: 100%;
@@ -90,7 +90,7 @@
   }
 
   .main-content {
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       /* Set a min height for the content to keep the help button sticky to the
        * bottom of the screen when the content does not fill the viewport.
        * Help button with margin has height of 80 px. Height of help button and
@@ -104,7 +104,7 @@
   .nav-burger {
     display: none;
 
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       display: block;
       font-size: 20px;
       padding-bottom: 5px;

--- a/packages/terra-consumer-layout/tests/nightwatch/LayoutTests.scss
+++ b/packages/terra-consumer-layout/tests/nightwatch/LayoutTests.scss
@@ -1,7 +1,7 @@
 @import '../../src/variables';
 
 h1 {
-  @media screen and (max-width: $terra-medium-breakpoint) {
+  @media screen and (max-width: $terra-medium-breakpoint - 1) {
     margin-top: 40px;
   }
 }

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -5,6 +5,11 @@ ChangeLog
 - Fixed punch through effect
 
 
+# Unreleased
+
+### Changed
+- Align media query with terra-core
+
 # 0.2.5 - (October 06, 2017)
 
 ### Added

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -3,12 +3,9 @@ ChangeLog
 
 ### Changed
 - Fixed punch through effect
-
-
-# Unreleased
-
-### Changed
 - Align media query with terra-core
+
+------------------
 
 # 0.2.5 - (October 06, 2017)
 

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -7,13 +7,13 @@
     padding-bottom: 70px;
     padding-top: var(--terra-consumer-nav-padding-top, 25px);
     user-select: none;
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       padding-bottom: 0;
     }
   }
 
   .modal-open {
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       height: 100vh;
       overflow: hidden;
     }
@@ -24,7 +24,7 @@
     position: fixed;
     width: var(--terra-consumer-profile-link-width, 320px);
 
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       position: static;
     }
   }
@@ -37,7 +37,7 @@
     position: absolute;
     right: 0;
     top: 0;
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       display: block;
     }
   }

--- a/packages/terra-consumer-nav/src/components/modal/Modal.scss
+++ b/packages/terra-consumer-nav/src/components/modal/Modal.scss
@@ -11,7 +11,7 @@
     right: 20px;
     top: 60px;
 
-    @media screen and (max-width: $terra-tiny-breakpoint) {
+    @media screen and (max-width: $terra-tiny-breakpoint - 1) {
       left: 10px;
       max-height: calc(100% - 70px);
       right: 10px;
@@ -32,7 +32,7 @@
   .overlay {
     background-color: var(--terra-consumer--overlay-background, #64696c) !important;
     opacity: 1 !important;
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       height: 100vh;
       width: 100vw;
     }
@@ -45,7 +45,7 @@
     right: 20px;
     top: 0;
 
-    @media screen and (max-width: $terra-tiny-breakpoint) {
+    @media screen and (max-width: $terra-tiny-breakpoint - 1) {
       right: 15px;
     }
   }

--- a/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
+++ b/packages/terra-consumer-nav/src/components/nav-items/NavItem.scss
@@ -67,7 +67,7 @@
     font-weight: 900;
     position: relative;
 
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       background-attachment: none;
       background-image: none;
       background-size: none;

--- a/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.scss
+++ b/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.scss
@@ -11,7 +11,7 @@
     max-height: 170px;
     max-width: 100%;
     text-align: center;
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       margin: 40px 25px;
     }
   }

--- a/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
+++ b/packages/terra-consumer-nav/src/components/user-profile/UserProfile.scss
@@ -10,8 +10,7 @@
     @supports (-webkit-overflow-scrolling: touch) {
       background-image: none;
     }
-
-    @media screen and (max-width: $terra-tiny-breakpoint) {
+    @media screen and (max-width: $terra-tiny-breakpoint - 1) {
       width: 100vw;
     }
   }
@@ -43,7 +42,7 @@
   }
 
   .profile-item-border {
-    @media screen and (max-width: $terra-medium-breakpoint) {
+    @media screen and (max-width: $terra-medium-breakpoint - 1) {
       border-bottom: 1px solid #dedfe0;
     }
   }


### PR DESCRIPTION
### Summary
Terra-core and topia use min-width in media query. Terra-consumer uses the same breakpoints but with max-width. It introduces 1px off compared with terra-core media-query. In order to align with terra-core media query, this PR fixes the 1px difference.
 
Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
