### PR TITLE
Fixing burger bar without icon

### DIFF
--- a/packages/terra-consumer-layout/CHANGELOG.md
+++ b/packages/terra-consumer-layout/CHANGELOG.md
@@ -1,5 +1,10 @@
 ChangeLog
 
+# 0.2.2 - (November 03, 2017)
+- Fixes the nav hamburger button when there's no logo on mobile.
+
+------------------
+
 # 0.2.1 - (November 02, 2017)
 - Fixes center logo in mobile viewports.
 

--- a/packages/terra-consumer-layout/package.json
+++ b/packages/terra-consumer-layout/package.json
@@ -1,7 +1,7 @@
 {
   "name": "terra-consumer-layout",
   "main": "lib/Layout.js",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "description": "A re-usable layout component that puts together our navigation",
   "repository": {
     "type": "git",

--- a/packages/terra-consumer-layout/src/Layout.jsx
+++ b/packages/terra-consumer-layout/src/Layout.jsx
@@ -90,11 +90,11 @@ class Layout extends React.Component {
             <div className={cx('main-container-inner')}>
               <div className={cx('nav-burgerbar')}>
                 <Nav.Burger handleClick={this.toggleNav} />
-                {logo && logo.mobileLogo &&
-                  <div className={cx('mobile-logo')}>
+                <div className={cx('mobile-logo')}>
+                  {logo && logo.mobileLogo &&
                     <img src={logo.mobileLogo.url} alt={logo.mobileLogo.altText} />
-                  </div>
-                }
+                  }
+                </div>
               </div>
               <div className={cx('main-content')}>{this.props.children}</div>
               <Nav.Help className={cx('help-button')} helpNavs={helpItems} id="nav-help-button" />

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -123,6 +123,7 @@
     display: flex;
     justify-content: center;
     width: 100%;
+    height: 35px;
 
     img {
       max-height: 35px;

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -122,8 +122,8 @@
   .mobile-logo {
     display: flex;
     justify-content: center;
-    width: 100%;
     height: 35px;
+    width: 100%;
 
     img {
       max-height: 35px;

--- a/packages/terra-consumer-layout/src/Layout.scss
+++ b/packages/terra-consumer-layout/src/Layout.scss
@@ -121,8 +121,8 @@
 
   .mobile-logo {
     display: flex;
-    justify-content: center;
     height: 35px;
+    justify-content: center;
     width: 100%;
 
     img {


### PR DESCRIPTION
### Summary
This PR fixes the overlapping issue of nav burger icon when there's no mobile logo configured.

DETAIL: in the previous release, we set burger button's `position` to `absolute` which takes it off the flow. However, that will take the whole nav bar off if img is not the nav bar. So we're adding an img holder that has a fixed height to keep that position.  

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
