### PR TITLE
Updated help button content element to allow user copying content in subitem

### DIFF
--- a/packages/terra-consumer-layout/tests/nightwatch/PortalLayout.jsx
+++ b/packages/terra-consumer-layout/tests/nightwatch/PortalLayout.jsx
@@ -331,7 +331,7 @@ const data = {
       text: 'Get Support ID',
       icon: (<IconOutlineQuestionMark />),
       children: [{
-        text: 'Need help using this portal or need to report an issue? Contact the support team at 123-xxx-xxxx',
+        text: 'abcdefghiJ01234Cerner56789Mnopqrstuvwxyz',
       }],
     },
     {

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,4 +1,11 @@
 ChangeLog
+# 0.2.10 - (December 07, 2018)
+### Changed
+- Updated the help button content with toggle.Toggle content is separated from
+- toggle header.
+
+
+------------------
 # 0.2.9 - (November 21, 2017)
 ### Added
 - Added custom callback functions to profile links for click events

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,9 +1,8 @@
 ChangeLog
-# 0.2.10 - (December 07, 2018)
+# 0.2.10 - (December 07, 2017)
 ### Changed
 - Updated the help button content with toggle.Toggle content is separated from
 - toggle header.
-
 
 ------------------
 # 0.2.9 - (November 21, 2017)

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
@@ -47,8 +47,10 @@
     }
   }
 
-  .help-item-border {
-    border-top: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
+  .border-top-except-first-element {
+    &:not(:first-child) {
+      border-top: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
+    }
   }
 
   .help-item-text {

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
@@ -37,6 +37,10 @@
     text-decoration: none;
     width: 100%;
 
+    &:not(:first-child) {
+      border-top: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
+    }
+
     &:hover {
       background: var(--terra-consumer--nav-help-item-hover-background, #eee);
       cursor: pointer;
@@ -47,7 +51,7 @@
     }
   }
 
-  .border-top-except-first-element {
+  .help-item-wrapper {
     &:not(:first-child) {
       border-top: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
     }

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
@@ -30,7 +30,6 @@
   .help-item {
     background: var(--terra-consumer--nav-help-item-background, #fff);
     border: 0;
-    border-bottom: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
     border-radius: 0;
     display: block;
     font-family: inherit;
@@ -48,6 +47,10 @@
     }
   }
 
+  .help-item-border {
+    border-top: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
+  }
+
   .help-item-text {
     color: var(--terra-consumer--nav-help-item-text-color, #383f42);
     font-size: 14px;
@@ -59,6 +62,7 @@
     color: var(--terra-consumer--nav-help-subitem-text-color, #64696c);
     font-size: 14px;
     line-height: 18px;
+    overflow-wrap: break-word;
     text-decoration: none;
   }
 
@@ -75,8 +79,7 @@
   }
 
   .toggler-content-alignment {
-    padding-right: 20px;
-    padding-top: 20px;
+    padding: 0 40px 20px 20px;
     text-align: left;
   }
 

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -46,10 +46,10 @@ class NavHelpContent extends React.Component {
       const toggleIcon = isOpen ? <IconChevronUp /> : <IconChevronDown />;
 
       if (content.children && content.children.length > 0) {
-        contentElement = (<Button
-          key={`${content.text}`}
+        const helpItemStyle = cx('help-item', index > 0 ? 'help-item-border' : '');
+        contentElement = (<div key={`${content.text}`} ><Button
           onClick={() => this.handleToggle(index)}
-          className={cx('help-item')}
+          className={helpItemStyle}
         >
           <Arrange
             className={cx('help-item-text')}
@@ -58,6 +58,7 @@ class NavHelpContent extends React.Component {
             fill={<div><SafeHtml text={content.text} /></div>}
             fitEnd={<div>{toggleIcon}</div>}
           />
+        </Button>
           <Toggler isOpen={isOpen} isAnimated={false} className={cx('toggler-padding')}>
             { content.children.map(element => (
               <p key={`${element.text}`} className={cx('toggler-content-alignment')}>
@@ -67,11 +68,12 @@ class NavHelpContent extends React.Component {
               </p>))
           }
           </Toggler>
-        </Button>);
+        </div>);
       } else {
+        const helpItemStyle = cx('help-item', index > 0 ? 'help-item-border' : '');
         contentElement = (
           <SmartLink
-            className={cx('help-item')}
+            className={helpItemStyle}
             key={content.text}
             url={content.url}
             target={content.target}

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -44,10 +44,10 @@ class NavHelpContent extends React.Component {
       let contentElement;
       const isOpen = this.state.togglers[index];
       const toggleIcon = isOpen ? <IconChevronUp /> : <IconChevronDown />;
+      const helpItemStyle = cx('help-item', index > 0 && 'help-item-border');
 
       if (content.children && content.children.length > 0) {
-        const helpItemStyle = cx('help-item', index > 0 ? 'help-item-border' : '');
-        contentElement = (<div key={`${content.text}`} ><Button
+        contentElement = (<div key={content.text} ><Button
           onClick={() => this.handleToggle(index)}
           className={helpItemStyle}
         >
@@ -61,7 +61,7 @@ class NavHelpContent extends React.Component {
         </Button>
           <Toggler isOpen={isOpen} isAnimated={false} className={cx('toggler-padding')}>
             { content.children.map(element => (
-              <p key={`${element.text}`} className={cx('toggler-content-alignment')}>
+              <p key={element.text} className={cx('toggler-content-alignment')}>
                 <span className={cx('help-subitem')}>
                   <SafeHtml text={element.text} />
                 </span>
@@ -70,7 +70,6 @@ class NavHelpContent extends React.Component {
           </Toggler>
         </div>);
       } else {
-        const helpItemStyle = cx('help-item', index > 0 ? 'help-item-border' : '');
         contentElement = (
           <SmartLink
             className={helpItemStyle}

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -44,35 +44,39 @@ class NavHelpContent extends React.Component {
       let contentElement;
       const isOpen = this.state.togglers[index];
       const toggleIcon = isOpen ? <IconChevronUp /> : <IconChevronDown />;
-      const helpItemStyle = cx('help-item', index > 0 && 'help-item-border');
 
       if (content.children && content.children.length > 0) {
-        contentElement = (<div key={content.text} ><Button
-          onClick={() => this.handleToggle(index)}
-          className={helpItemStyle}
-        >
-          <Arrange
-            className={cx('help-item-text')}
-            align="stretch"
-            fitStart={<div className={cx('icon-text-padding')}>{content.icon}</div>}
-            fill={<div><SafeHtml text={content.text} /></div>}
-            fitEnd={<div>{toggleIcon}</div>}
-          />
-        </Button>
-          <Toggler isOpen={isOpen} isAnimated={false} className={cx('toggler-padding')}>
-            { content.children.map(element => (
-              <p key={element.text} className={cx('toggler-content-alignment')}>
-                <span className={cx('help-subitem')}>
-                  <SafeHtml text={element.text} />
-                </span>
-              </p>))
-          }
-          </Toggler>
-        </div>);
+        contentElement = (
+          <div
+            className={cx('border-top-except-first-element')}
+            key={content.text}
+          >
+            <Button
+              className={cx('help-item')}
+              onClick={() => this.handleToggle(index)}
+            >
+              <Arrange
+                className={cx('help-item-text')}
+                align="stretch"
+                fitStart={<div className={cx('icon-text-padding')}>{content.icon}</div>}
+                fill={<div><SafeHtml text={content.text} /></div>}
+                fitEnd={<div>{toggleIcon}</div>}
+              />
+            </Button>
+            <Toggler isOpen={isOpen} isAnimated={false} className={cx('toggler-padding')}>
+              { content.children.map(element => (
+                <p key={element.text} className={cx('toggler-content-alignment')}>
+                  <span className={cx('help-subitem')}>
+                    <SafeHtml text={element.text} />
+                  </span>
+                </p>))
+              }
+            </Toggler>
+          </div>);
       } else {
         contentElement = (
           <SmartLink
-            className={helpItemStyle}
+            className={cx('help-item', 'border-top-except-first-element')}
             key={content.text}
             url={content.url}
             target={content.target}

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -48,7 +48,7 @@ class NavHelpContent extends React.Component {
       if (content.children && content.children.length > 0) {
         contentElement = (
           <div
-            className={cx('border-top-except-first-element')}
+            className={cx('help-item-wrapper')}
             key={content.text}
           >
             <Button
@@ -76,7 +76,7 @@ class NavHelpContent extends React.Component {
       } else {
         contentElement = (
           <SmartLink
-            className={cx('help-item', 'border-top-except-first-element')}
+            className={cx('help-item')}
             key={content.text}
             url={content.url}
             target={content.target}

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
@@ -2,7 +2,9 @@
 
 exports[`Content of the Help Modal/Popup should render a list of items with/without toggler 1`] = `
 <div>
-  <div>
+  <div
+    className="border-top-except-first-element"
+  >
     <Button
       className="help-item"
       isBlock={false}
@@ -67,7 +69,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
     </Toggle>
   </div>
   <SmartLink
-    className="help-item help-item-border"
+    className="help-item border-top-except-first-element"
     handleClick={[Function]}
     isExternal={false}
     target="_self"

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
@@ -2,50 +2,52 @@
 
 exports[`Content of the Help Modal/Popup should render a list of items with/without toggler 1`] = `
 <div>
-  <Button
-    className="help-item"
-    isBlock={false}
-    isCompact={false}
-    isDisabled={false}
-    isReversed={false}
-    onClick={[Function]}
-    type="button"
-    variant="default"
-  >
-    <Arrange
-      align="stretch"
-      className="help-item-text"
-      fill={
-        <div>
-          <SafeHtml
-            text="Technical Questions"
-          />
-        </div>
-      }
-      fitEnd={
-        <div>
-          <IconChevronDown
-            className=""
-            data-name="Layer 1"
-            isBidi={true}
-            viewBox="0 0 48 48"
-            xmlns="http://www.w3.org/2000/svg"
-          />
-        </div>
-      }
-      fitStart={
-        <div
-          className="icon-text-padding"
-        >
-          <IconOutlineQuestionMark
-            height={16}
-            viewBox="0 0 48 48"
-            width={16}
-            xmlns="http://www.w3.org/2000/svg"
-          />
-        </div>
-      }
-    />
+  <div>
+    <Button
+      className="help-item"
+      isBlock={false}
+      isCompact={false}
+      isDisabled={false}
+      isReversed={false}
+      onClick={[Function]}
+      type="button"
+      variant="default"
+    >
+      <Arrange
+        align="stretch"
+        className="help-item-text"
+        fill={
+          <div>
+            <SafeHtml
+              text="Technical Questions"
+            />
+          </div>
+        }
+        fitEnd={
+          <div>
+            <IconChevronDown
+              className=""
+              data-name="Layer 1"
+              isBidi={true}
+              viewBox="0 0 48 48"
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </div>
+        }
+        fitStart={
+          <div
+            className="icon-text-padding"
+          >
+            <IconOutlineQuestionMark
+              height={16}
+              viewBox="0 0 48 48"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            />
+          </div>
+        }
+      />
+    </Button>
     <Toggle
       className="toggler-padding"
       isAnimated={false}
@@ -63,9 +65,9 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
         </span>
       </p>
     </Toggle>
-  </Button>
+  </div>
   <SmartLink
-    className="help-item"
+    className="help-item help-item-border"
     handleClick={[Function]}
     isExternal={false}
     target="_self"

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelpContent.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Content of the Help Modal/Popup should render a list of items with/without toggler 1`] = `
 <div>
   <div
-    className="border-top-except-first-element"
+    className="help-item-wrapper"
   >
     <Button
       className="help-item"
@@ -69,7 +69,7 @@ exports[`Content of the Help Modal/Popup should render a list of items with/with
     </Toggle>
   </div>
   <SmartLink
-    className="help-item border-top-except-first-element"
+    className="help-item"
     handleClick={[Function]}
     isExternal={false}
     target="_self"


### PR DESCRIPTION

### Summary
Support/request ID not copyable after UI Uplift. Each item in Help pop is a button. When there is subitem clicking the button toggle the content. Since the toggle content is inside a button user cannot select the text inside the button. There is requirement for Portal to allow the user to copy a support id (ex. 1be787bfa7594928d4f5de2991c399ab) from the popup. 

Updated the Help popup/modal content component by separating the toggle header and toggle content. Toggle content is a paragraph, so the user can copy the content.Also added overflow-wrap CSS  property for the content, because the long string like this id 1be787bfa7594928d4f5de2991c399ab is not wrapping.

**Note**: 
**overflow-wrap: break-word**  is working for chrome,safari & firefox but not in ie/edge. Please let me know if you have any suggestion to wrap the long string like support ID mentioned above.

**Before**:

![helpbuttontoggle_before](https://user-images.githubusercontent.com/21693381/33734450-5c0cd37c-db5a-11e7-99e3-c5da06ac1e23.gif)

**After**

![helpbuttontoggle_after](https://user-images.githubusercontent.com/21693381/33734466-6ca2af04-db5a-11e7-8386-bc31b83bfb86.gif)

Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
