### PR TITLE
Updated help button and help-item hover background

### DIFF
--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,4 +1,11 @@
 ChangeLog
+# 0.2.11 - (December 18, 2017)
+### Changed
+- Updated the hover background for help-button and popup content to make it
+- consistent with profile button and content.
+- Updated the margin and padding for toggle content in help popup.
+
+------------------
 # 0.2.10 - (December 07, 2017)
 ### Changed
 - Updated the help button content with toggle.Toggle content is separated from

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,8 +1,7 @@
 ChangeLog
-# 0.2.11 - (December 18, 2017)
+# 0.2.11 - (December 21, 2017)
 ### Changed
-- Updated the hover background for help-button and popup content to make it
-- consistent with profile button and content.
+- Updated the hover background for help-button and popup content to make it consistent with profile button and content.
 - Updated the margin and padding for toggle content in help popup.
 
 ------------------

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelp.scss
@@ -14,12 +14,12 @@
     padding: 6px 13px;
 
     &:hover {
-      background: var(--terra-consumer--nav-help-button-hover-background, #eee);
+      background: var(--terra-consumer--nav-help-button-hover-background, #cfd0d1);
       cursor: pointer;
     }
 
     &:focus {
-      background: var(--terra-consumer--nav-help-button-focus-background, #eee);
+      background: var(--terra-consumer--nav-help-button-focus-background, #cfd0d1);
     }
 
     &:active {
@@ -42,19 +42,25 @@
     }
 
     &:hover {
-      background: var(--terra-consumer--nav-help-item-hover-background, #eee);
+      background: var(--terra-consumer--nav-help-item-hover-background, #cfd0d1);
       cursor: pointer;
     }
 
     &:focus {
-      background: var(--terra-consumer--nav-help-item-focus-background, #eee);
+      background: var(--terra-consumer--nav-help-item-focus-background, #cfd0d1);
     }
   }
 
   .help-item-wrapper {
+    background: #f3f3f3;
+
     &:not(:first-child) {
       border-top: 1px solid var(--terra-consumer--nav-help-item-border-color, #dedfe0);
     }
+  }
+
+  .toggler-open {
+    background: #f3f3f3;
   }
 
   .help-item-text {
@@ -85,7 +91,8 @@
   }
 
   .toggler-content-alignment {
-    padding: 0 40px 20px 20px;
+    margin: 0;
+    padding: 10px 40px 20px 20px;
     text-align: left;
   }
 

--- a/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-help/NavHelpContent.jsx
@@ -52,7 +52,7 @@ class NavHelpContent extends React.Component {
             key={content.text}
           >
             <Button
-              className={cx('help-item')}
+              className={cx('help-item', { 'toggler-open': isOpen })}
               onClick={() => this.handleToggle(index)}
             >
               <Arrange


### PR DESCRIPTION
### Summary
- Updated the help button and help-item hover background to make it consistent with profile item popup.
- Updated the margin and padding for toggle content in help popup based on UX feedback.

Before:

![help_button_hover_before](https://user-images.githubusercontent.com/21693381/34127792-63c1f81c-e40c-11e7-88b6-894cfb4d7f3b.gif)

After:

![help_button_hover_after](https://user-images.githubusercontent.com/21693381/34127990-289cc996-e40d-11e7-8b36-9eea3b207a94.gif)



Please add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
