### PR TITLE
move storybook addons to devDependencies

### DIFF
--- a/packages/terra-consumer-icon/CHANGELOG.md
+++ b/packages/terra-consumer-icon/CHANGELOG.md
@@ -1,8 +1,12 @@
 ChangeLog
 =========
+Unreleased
+- Move storybook from peerDependencies to devDependencies to avoid warnings in
+applications using this package.
+
 1.2.2 - (September 14, 2017)
 ----------
-Adding outline user icon 
+Adding outline user icon
 
 1.2.1 - (September 06, 2017)
 ----------

--- a/packages/terra-consumer-icon/package.json
+++ b/packages/terra-consumer-icon/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/cerner/terra-consumer#readme",
   "devDependencies": {
+    "@storybook/react": "^3.2.14",
     "csvtojson": "^1.1.4",
     "jsdom": "^9.11.0",
     "one-cerner-style-icons": "https://github.com/cerner/one-cerner-style-icons/archive/v1.0.0.tar.gz",
@@ -31,7 +32,6 @@
     "terra-toolkit": "^1.2.2"
   },
   "peerDependencies": {
-    "@storybook/react": "^3.2.14",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "terra-base": "^2.1.0"

--- a/packages/terra-consumer-icon/stories/Index.jsx
+++ b/packages/terra-consumer-icon/stories/Index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from '@storybook/react';
 import IconStatic from './IconStatic';
 import IconThemeable from './IconThemeable';

--- a/packages/terra-consumer-layout/CHANGELOG.md
+++ b/packages/terra-consumer-layout/CHANGELOG.md
@@ -1,5 +1,9 @@
 ChangeLog
 
+Unreleased
+- Move storybook from peerDependencies to devDependencies to avoid warnings in
+applications using this package.
+
 # 0.2.4 - (November 10, 2017)
 
 ### Changed

--- a/packages/terra-consumer-layout/package.json
+++ b/packages/terra-consumer-layout/package.json
@@ -23,7 +23,6 @@
   },
   "homepage": "https://github.com/cerner/terra-consumer#readme",
   "peerDependencies": {
-    "@storybook/react": "^3.2.14",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-router-dom": "^4.2.2",
@@ -42,6 +41,7 @@
     "terra-responsive-element": "^1.7.0"
   },
   "devDependencies": {
+    "@storybook/react": "^3.2.14",
     "terra-alert": "^1.9.1"
   },
   "scripts": {

--- a/packages/terra-consumer-layout/stories/Index.jsx
+++ b/packages/terra-consumer-layout/stories/Index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { storiesOf } from '@storybook/react';
 import DexLayout from './DexLayout';
 import PortalLayout from './PortalLayout';

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,10 +1,14 @@
 ChangeLog
+
 # 0.2.11 - (December 21, 2017)
 ### Changed
 - Updated the hover background for help-button and popup content to make it consistent with profile button and content.
 - Updated the margin and padding for toggle content in help popup.
+- Move storybook from peerDependencies to devDependencies to avoid warnings in
+applications using this package.
 
 ------------------
+
 # 0.2.10 - (December 07, 2017)
 ### Changed
 - Updated the help button content with toggle.Toggle content is separated from

--- a/packages/terra-consumer-nav/package.json
+++ b/packages/terra-consumer-nav/package.json
@@ -23,8 +23,6 @@
   },
   "homepage": "https://github.com/cerner/terra-consumer#readme",
   "peerDependencies": {
-    "@storybook/addon-actions": "^3.3.0-alpha.4",
-    "@storybook/react": "^3.2.14",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "terra-base": "^2.1.0",
@@ -50,6 +48,8 @@
     "terra-toggle": "^1.6.0"
   },
   "devDependencies": {
+    "@storybook/addon-actions": "^3.3.0-alpha.4",
+    "@storybook/react": "^3.2.14",
     "terra-props-table": "^1.5.0"
   },
   "scripts": {

--- a/packages/terra-consumer-nav/stories/Index.jsx
+++ b/packages/terra-consumer-nav/stories/Index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+/* eslint-disable import/no-extraneous-dependencies */
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import NavBurger from '../src/components/nav-burger-button/NavBurgerButton';


### PR DESCRIPTION
to avoid applications from getting peerDependencies warnings

Thanks for contributing to Terra. 
@cerner/terra

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
