### PR TITLE
remove missing logo icon on certain browsers

### DIFF
--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,5 +1,11 @@
 ChangeLog
 
+# Unreleased
+### Changed
+- NavLogo now renders a p tag if no url is passed to avoid missing image icon in chrome/safari/ie
+
+------------------
+
 # 0.2.11 - (December 21, 2017)
 ### Changed
 - Updated the hover background for help-button and popup content to make it consistent with profile button and content.

--- a/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-logo/NavLogo.jsx
@@ -43,10 +43,17 @@ const NavLogo = ({
 }) => {
   const imgProps = {
     className: cx('img'),
-    ...url && { src: url },
+    ...url ? {
+      src: url,
+      alt: altText,
+    } : {
+      children: altText,
+    },
   };
 
-  const imgTag = (<img alt={altText} {...imgProps} />);
+  const LogoElement = url ? 'img' : 'p';
+
+  const imgTag = (<LogoElement {...imgProps} />);
   const imgContent = (link) ? <SmartLink {...link}>{imgTag} </SmartLink> : imgTag;
   const body = (isCard && !!url) ? <Card.Body> {imgContent} </Card.Body> : imgContent;
   const domNode = (isCard && !!url) ? Card : 'div';

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavLogo.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavLogo.test.jsx.snap
@@ -47,9 +47,10 @@ exports[`Nav Logo should render a div regardless of isCard when no url is provid
 <div
   className="logo-container"
 >
-  <img
-    alt="test"
+  <p
     className="img"
-  />
+  >
+    test
+  </p>
 </div>
 `;

--- a/packages/terra-consumer-nav/tests/nightwatch/NavLogoTest.jsx
+++ b/packages/terra-consumer-nav/tests/nightwatch/NavLogoTest.jsx
@@ -4,7 +4,7 @@ import I18nShell from './I18nShell';
 
 const logoWithOutURL = {
   url: '',
-  altText: 'Nike',
+  altText: 'Alt Text Test',
   isCard: true,
 };
 


### PR DESCRIPTION
### Summary
Change nav logo to render a p tag if no url is passed to avoid missing image icon in chrome/safari/ie

Before:

<img width="333" alt="image" src="https://user-images.githubusercontent.com/30411845/34575209-e3b35f0a-f147-11e7-8440-80e52e73cc28.png">

After:

<img width="363" alt="image" src="https://user-images.githubusercontent.com/30411845/34575253-093f3050-f148-11e7-8ba4-b1f9f75d2d83.png">
