### PR TITLE
Remove roboto and update examples

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,16 @@
 <script>
   document.documentElement.setAttribute("dir", "ltr");
 </script>
+<script>
+   WebFontConfig = {
+      google: {
+        families: ['Roboto']
+      }
+   };
+   (function(d) {
+      var wf = d.createElement('script'), s = d.scripts[0];
+      wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
+      wf.async = true;
+      s.parentNode.insertBefore(wf, s);
+   })(document);
+</script>

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,4 +1,7 @@
 ChangeLog
+# Next Release
+#### changed
+- Removed Roboto font import for stylesheet.
 
 # 0.2.12 - (Jan 5, 2018)
 ### Changed

--- a/packages/terra-consumer-nav/src/Nav.scss
+++ b/packages/terra-consumer-nav/src/Nav.scss
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700,900');
 @import './variables';
 
 :local {

--- a/packages/terra-consumer-site/src/index.html
+++ b/packages/terra-consumer-site/src/index.html
@@ -5,6 +5,19 @@
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Terra Consumer</title>
+    <script>
+       WebFontConfig = {
+          google: {
+            families: ['Roboto']
+          }
+       };
+       (function(d) {
+          var wf = d.createElement('script'), s = d.scripts[0];
+          wf.src = 'https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js';
+          wf.async = true;
+          s.parentNode.insertBefore(wf, s);
+       })(document);
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/terra-consumer-site/webpack.config.js
+++ b/packages/terra-consumer-site/webpack.config.js
@@ -14,6 +14,7 @@ const rtl = require('postcss-rtl');
 
 const customProperties = CustomProperties({ preserve: true, warnings: false });
 customProperties.setVariables({
+  '--terra-base-font-family': 'Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif',
   // Body
   '--terra-consumer-body-background-color': '#c7d4ea',
   // Nav


### PR DESCRIPTION
### Summary
Remove roboto from being hardcoded imported. This forces all consumers to incur the cost of loading the roboto font even if its not being used. Roboto should be configured by the consuming application to be loaded dynamically using https://github.com/typekit/webfontloader