### PR TITLE
Adding prop aria-label to Nav buttons

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ Cerner Corporation
 - Alex Bezek [@alex-bezek]
 - Jim Pruetting [@jpruetting]
 - Yaonan Zhong [@zhongyn]
+- Raihan Ahmed Mohammed [@MohammedRAihanAhmed]
 
 [@mhemesath]: https://github.com/mhemesath
 [@KevinJJackson]: https://github.com/KevinJJackson
@@ -17,3 +18,4 @@ Cerner Corporation
 [@Mahmud-Khan]:https://github.com/Mahmud-Khan
 [@jpruetting]:https://github.com/jpruetting
 [@zhongyn]:https://github.com/zhongyn
+[@MohammedRAihanAhmed]:https://github.com/MohammedRAihanAhmed

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -9,6 +9,12 @@ ChangeLog
 
 ------------------
 
+# 0.2.13 - (Jan 25, 2018)
+### Added
+- Added an aria-label custom prop to NavBurgerButton and Nav close button. 
+
+------------------
+
 # 0.2.12 - (Jan 5, 2018)
 ### Changed
 - NavLogo now renders a p tag if no url is passed to avoid missing image icon in chrome/safari/ie

--- a/packages/terra-consumer-nav/src/Nav.jsx
+++ b/packages/terra-consumer-nav/src/Nav.jsx
@@ -135,7 +135,7 @@ class Nav extends React.Component {
         className={cx('nav', { 'modal-open': this.state.isModalOpen }, customProps.className)}
       >
         <div className={cx('close-button-container')}>
-          <Button icon={<IconClose />} className={cx('close-button')} onClick={() => { onRequestClose(); }} variant="link" />
+          <Button icon={<IconClose />} className={cx('close-button')} onClick={() => { onRequestClose(); }} variant="link" aria-label="Close" />
         </div>
         <NavLogo {...logo} />
         <NavItems navItems={navItems} handleClick={onRequestClose} />

--- a/packages/terra-consumer-nav/src/components/nav-burger-button/NavBurgerButton.jsx
+++ b/packages/terra-consumer-nav/src/components/nav-burger-button/NavBurgerButton.jsx
@@ -20,10 +20,10 @@ const NavBurger = ({
     onClick={handleClick}
     icon={<IconMenu />}
     variant="link"
+    aria-label="Open Navbar"
     className={cx('burger', customProps.className)}
   />
 );
 
 NavBurger.propTypes = propTypes;
-
 export default NavBurger;

--- a/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/__snapshots__/Nav.test.jsx.snap
@@ -10,6 +10,7 @@ exports[`Nav should render a default component 1`] = `
     className="close-button-container"
   >
     <Button
+      aria-label="Close"
       className="close-button"
       icon={
         <IconClose
@@ -113,6 +114,7 @@ exports[`Nav without profile should render a nav without a profile component 1`]
     className="close-button-container"
   >
     <Button
+      aria-label="Close"
       className="close-button"
       icon={
         <IconClose

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavBurgerButton.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavBurgerButton.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Nav Burger should render a default component 1`] = `
 <Button
+  aria-label="Open Navbar"
   className="burger"
   icon={
     <IconMenu
@@ -22,6 +23,7 @@ exports[`Nav Burger should render a default component 1`] = `
 
 exports[`Nav Burger should render accept custom classes 1`] = `
 <Button
+  aria-label="Open Navbar"
   className="burger testClass"
   icon={
     <IconMenu
@@ -42,6 +44,7 @@ exports[`Nav Burger should render accept custom classes 1`] = `
 
 exports[`Nav Burger should render accept custom props 1`] = `
 <Button
+  aria-label="Open Navbar"
   className="burger"
   icon={
     <IconMenu


### PR DESCRIPTION
### Summary
Button Components in terra-consumer-nav are missing aria-label, this makes them inaccessible to users relying on accessibility devices to access content on applications consuming terra-consumer-nav. Aria-label attribute is also suggested by the WCAG guidelines https://www.w3.org/TR/WCAG20-TECHS/ARIA6.html. 
These button components are added an aria-label as part of this pull request.

### Additional Details
Issue created with additional details : https://github.com/cerner/terra-consumer/issues/108
