### PR TITLE
PORTALDEV-41735 Update transalation texts for help button

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@ Cerner Corporation
 - Jim Pruetting [@jpruetting]
 - Yaonan Zhong [@zhongyn]
 - Raihan Ahmed Mohammed [@MohammedRAihanAhmed]
+- Divya Ashritha [@DivyaAshritha]
 
 [@mhemesath]: https://github.com/mhemesath
 [@KevinJJackson]: https://github.com/KevinJJackson
@@ -19,3 +20,4 @@ Cerner Corporation
 [@jpruetting]:https://github.com/jpruetting
 [@zhongyn]:https://github.com/zhongyn
 [@MohammedRAihanAhmed]:https://github.com/MohammedRAihanAhmed
+[@DivyaAshritha]:https://github.com/divyaashritha

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,6 +1,12 @@
 ChangeLog
 # Next Release
 
+# 0.2.14 - (Feb 12, 2018)
+### Changed
+- Updated the translation texts for help button
+
+------------------
+
 # 0.2.13 - (Jan 30, 2018)
 ### Added
 - Ability to open parent nav when directed to a sub navigation item from dashboard

--- a/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelp.test.jsx.snap
+++ b/packages/terra-consumer-nav/tests/jest/components/__snapshots__/NavHelp.test.jsx.snap
@@ -5,7 +5,7 @@ exports[`NavHelp button with pop/modal should render a button with IconInfo,labe
   locale="en-US"
   messages={
     Object {
-      "Terra.Consumer.NavHelp.help": "Help",
+      "Terra.Consumer.NavHelp.help": "Info",
       "Terra.Consumer.UserProfile.Modal.title": "Settings",
       "Terra.Consumer.UserProfile.signin": "Sign In",
       "Terra.Consumer.UserProfile.signout": "Sign Out",

--- a/packages/terra-consumer-nav/translations/ar.json
+++ b/packages/terra-consumer-nav/translations/ar.json
@@ -1,5 +1,5 @@
 {
-  "Terra.Consumer.NavHelp.help": "المساعدة",
+  "Terra.Consumer.NavHelp.help": "مَعْلومات",
   "Terra.Consumer.UserProfile.Modal.title": "الإعدادات",
   "Terra.Consumer.UserProfile.signout": "تسجيل الخروج",
   "Terra.Consumer.UserProfile.signin": "تسجيل الدخول"

--- a/packages/terra-consumer-nav/translations/en-GB.json
+++ b/packages/terra-consumer-nav/translations/en-GB.json
@@ -1,5 +1,5 @@
 {
-  "Terra.Consumer.NavHelp.help": "Help",
+  "Terra.Consumer.NavHelp.help": "Info",
   "Terra.Consumer.UserProfile.Modal.title": "Settings",
   "Terra.Consumer.UserProfile.signout": "Sign Out",
   "Terra.Consumer.UserProfile.signin": "Sign In"

--- a/packages/terra-consumer-nav/translations/en-US.json
+++ b/packages/terra-consumer-nav/translations/en-US.json
@@ -1,5 +1,5 @@
 {
-	"Terra.Consumer.NavHelp.help": "Help",
+	"Terra.Consumer.NavHelp.help": "Info",
 	"Terra.Consumer.UserProfile.Modal.title": "Settings",
 	"Terra.Consumer.UserProfile.signout": "Sign Out",
 	"Terra.Consumer.UserProfile.signin": "Sign In"

--- a/packages/terra-consumer-nav/translations/en.json
+++ b/packages/terra-consumer-nav/translations/en.json
@@ -1,5 +1,5 @@
 {
-	"Terra.Consumer.NavHelp.help": "Help",
+	"Terra.Consumer.NavHelp.help": "Info",
 	"Terra.Consumer.UserProfile.Modal.title": "Settings",
 	"Terra.Consumer.UserProfile.signout": "Sign Out",
 	"Terra.Consumer.UserProfile.signin": "Sign In"

--- a/packages/terra-consumer-nav/translations/es-ES.json
+++ b/packages/terra-consumer-nav/translations/es-ES.json
@@ -1,5 +1,5 @@
 {
-  "Terra.Consumer.NavHelp.help": "Ayuda",
+  "Terra.Consumer.NavHelp.help": "Información",
   "Terra.Consumer.UserProfile.Modal.title": "Configuración",
   "Terra.Consumer.UserProfile.signout": "Cerrar sesión",
   "Terra.Consumer.UserProfile.signin": "Iniciar sesión"

--- a/packages/terra-consumer-nav/translations/es-US.json
+++ b/packages/terra-consumer-nav/translations/es-US.json
@@ -1,5 +1,5 @@
 {
-  "Terra.Consumer.NavHelp.help": "Ayuda",
+  "Terra.Consumer.NavHelp.help": "Información",
   "Terra.Consumer.UserProfile.Modal.title": "Configuración",
   "Terra.Consumer.UserProfile.signout": "Cerrar sesión",
   "Terra.Consumer.UserProfile.signin": "Iniciar sesión"

--- a/packages/terra-consumer-nav/translations/es.json
+++ b/packages/terra-consumer-nav/translations/es.json
@@ -1,5 +1,5 @@
 {
-  "Terra.Consumer.NavHelp.help": "Ayuda",
+  "Terra.Consumer.NavHelp.help": "Información",
   "Terra.Consumer.UserProfile.Modal.title": "Configuración",
   "Terra.Consumer.UserProfile.signout": "Cerrar sesión",
   "Terra.Consumer.UserProfile.signin": "Iniciar sesión"

--- a/packages/terra-consumer-nav/translations/fr-FR.json
+++ b/packages/terra-consumer-nav/translations/fr-FR.json
@@ -1,5 +1,5 @@
 {
-  "Terra.Consumer.NavHelp.help": "Aide",
+  "Terra.Consumer.NavHelp.help": "Info",
   "Terra.Consumer.UserProfile.Modal.title": "Paramètres",
   "Terra.Consumer.UserProfile.signout": "Déconnexion",
   "Terra.Consumer.UserProfile.signin": "Connexion"

--- a/packages/terra-consumer-nav/translations/fr.json
+++ b/packages/terra-consumer-nav/translations/fr.json
@@ -1,5 +1,5 @@
 {
-  "Terra.Consumer.NavHelp.help": "Aide",
+  "Terra.Consumer.NavHelp.help": "Info",
   "Terra.Consumer.UserProfile.Modal.title": "Paramètres",
   "Terra.Consumer.UserProfile.signout": "Déconnexion",
   "Terra.Consumer.UserProfile.signin": "Connexion"

--- a/packages/terra-consumer-nav/translations/pt-BR.json
+++ b/packages/terra-consumer-nav/translations/pt-BR.json
@@ -1,5 +1,5 @@
 {
-  "Terra.Consumer.NavHelp.help": "Ajuda",
+  "Terra.Consumer.NavHelp.help": "Informação",
   "Terra.Consumer.UserProfile.Modal.title": "Configurações",
   "Terra.Consumer.UserProfile.signout": "Sair",
   "Terra.Consumer.UserProfile.signin": "Entrar"


### PR DESCRIPTION
### Summary
[PORTALDEV-41735](https://jira2.cerner.com/browse/PORTALDEV-41735)

- Updated the translation for help button(used Google Translate for translations)

Before
![image](https://user-images.githubusercontent.com/22205502/36120394-a626d236-1008-11e8-8976-bf2b59bdd689.png)

After
![image](https://user-images.githubusercontent.com/22205502/36120488-f9e83bbc-1008-11e8-8b19-ed76ec023128.png)


