### PR TITLE
PORTALDEV-42421 added new translations for nl-BE in terra-consumer-nav

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ Cerner Corporation
 - Raihan Ahmed Mohammed [@MohammedRAihanAhmed]
 - Divya Ashritha [@DivyaAshritha]
 - Cody Price [@dev-cprice]
+- Wenxue Zhang [@zhangwenx]
 
 [@mhemesath]: https://github.com/mhemesath
 [@KevinJJackson]: https://github.com/KevinJJackson
@@ -23,3 +24,4 @@ Cerner Corporation
 [@MohammedRAihanAhmed]:https://github.com/MohammedRAihanAhmed
 [@DivyaAshritha]:https://github.com/divyaashritha
 [@dev-cprice]: https://github.com/dev-cprice
+[@zhangwenx]: https://github.com/zhangwenx

--- a/packages/terra-consumer-nav/CHANGELOG.md
+++ b/packages/terra-consumer-nav/CHANGELOG.md
@@ -1,6 +1,10 @@
 ChangeLog
 # Next Release
 
+# Unreleased
+### Changed
+- Added translations for new locale nl-BE.
+
 # 1.0.0
 --------
 - Upgrade to react 16

--- a/packages/terra-consumer-nav/translations/nl-BE.json
+++ b/packages/terra-consumer-nav/translations/nl-BE.json
@@ -1,5 +1,5 @@
 {
-  "Terra.Consumer.NavHelp.help": "Info",
+  "Terra.Consumer.NavHelp.help": "Informatie",
   "Terra.Consumer.UserProfile.Modal.title": "Instellingen",
   "Terra.Consumer.UserProfile.signout": "Afmelden",
   "Terra.Consumer.UserProfile.signin": "Aanmelden"

--- a/packages/terra-consumer-nav/translations/nl-BE.json
+++ b/packages/terra-consumer-nav/translations/nl-BE.json
@@ -1,0 +1,6 @@
+{
+  "Terra.Consumer.NavHelp.help": "Info",
+  "Terra.Consumer.UserProfile.Modal.title": "Settings",
+  "Terra.Consumer.UserProfile.signout": "Sign Out",
+  "Terra.Consumer.UserProfile.signin": "Sign In"
+}

--- a/packages/terra-consumer-nav/translations/nl-BE.json
+++ b/packages/terra-consumer-nav/translations/nl-BE.json
@@ -1,6 +1,6 @@
 {
   "Terra.Consumer.NavHelp.help": "Info",
-  "Terra.Consumer.UserProfile.Modal.title": "Settings",
-  "Terra.Consumer.UserProfile.signout": "Sign Out",
-  "Terra.Consumer.UserProfile.signin": "Sign In"
+  "Terra.Consumer.UserProfile.Modal.title": "Instellingen",
+  "Terra.Consumer.UserProfile.signout": "Afmelden",
+  "Terra.Consumer.UserProfile.signin": "Aanmelden"
 }


### PR DESCRIPTION
Added translations under terra-consumer-nav 


TO DO:
- the version will be bumped up when releasing. 
- will log a jira to translation team, then Dutch context for button context will be synced up.
